### PR TITLE
fix: detect helper signing mismatch and BTM desync instead of looping

### DIFF
--- a/Rockxy/Core/Certificate/CertificateManager.swift
+++ b/Rockxy/Core/Certificate/CertificateManager.swift
@@ -57,7 +57,8 @@ actor CertificateManager {
         case .notInstalled,
              .requiresApproval,
              .installedIncompatible,
-             .unreachable:
+             .unreachable,
+             .signingMismatch:
             return false
         }
     }

--- a/Rockxy/Core/ProxyEngine/HelperConnection.swift
+++ b/Rockxy/Core/ProxyEngine/HelperConnection.swift
@@ -15,6 +15,8 @@ enum HelperConnectionError: LocalizedError {
     case certInstallFailed(String)
     case certRemoveFailed(String)
     case bypassDomainsFailed(String)
+    case appSignatureInvalid(String)
+    case signingIdentityMismatch(app: String, helper: String)
 
     // MARK: Internal
 
@@ -36,8 +38,40 @@ enum HelperConnectionError: LocalizedError {
             "Helper failed to remove root certificate: \(reason)"
         case let .bypassDomainsFailed(reason):
             "Helper failed to set bypass domains: \(reason)"
+        case let .appSignatureInvalid(detail):
+            "This app build has an invalid code signature: \(detail)"
+        case let .signingIdentityMismatch(app, helper):
+            "This app is signed by \"\(app)\" but the installed helper was signed by \"\(helper)\""
         }
     }
+}
+
+// MARK: - SigningPreflightCache
+
+/// Memoized signing diagnostic. Caches the result until explicitly invalidated.
+/// Provider is injectable for tests.
+@MainActor
+final class SigningPreflightCache {
+    // MARK: Internal
+
+    var provider: () -> SigningDiagnostics.Result = { SigningDiagnostics.diagnose() }
+
+    func evaluate() -> SigningDiagnostics.Result {
+        if let cached {
+            return cached
+        }
+        let result = provider()
+        cached = result
+        return result
+    }
+
+    func invalidate() {
+        cached = nil
+    }
+
+    // MARK: Private
+
+    private var cached: SigningDiagnostics.Result?
 }
 
 // MARK: - HelperConnection
@@ -51,6 +85,8 @@ final class HelperConnection {
     // MARK: Internal
 
     static let shared = HelperConnection()
+
+    let signingCache = SigningPreflightCache()
 
     nonisolated static func performEmergencyProxyRestore(timeout: TimeInterval = 3) -> Bool {
         let connection = NSXPCConnection(machServiceName: Self.machServiceName, options: .privileged)
@@ -114,6 +150,10 @@ final class HelperConnection {
         }
 
         return succeeded
+    }
+
+    func invalidateSigningCache() {
+        signingCache.invalidate()
     }
 
     /// Check whether the helper daemon is installed and responding to XPC messages.
@@ -336,6 +376,7 @@ final class HelperConnection {
         }
         connection?.invalidate()
         connection = nil
+        signingCache.invalidate()
     }
 
     /// Set the system proxy bypass domain list via the helper tool.
@@ -563,8 +604,25 @@ final class HelperConnection {
 
     private var connection: NSXPCConnection?
 
+    /// Evaluate the signing preflight cache and throw a typed error if the
+    /// current app has a signing issue relative to the installed helper.
+    private func signingPreflight() throws {
+        let result = signingCache.evaluate()
+        switch result {
+        case let .appSignatureInvalid(detail):
+            throw HelperConnectionError.appSignatureInvalid(detail)
+        case let .signingIdentityMismatch(app, helper):
+            throw HelperConnectionError.signingIdentityMismatch(app: app, helper: helper)
+        case .healthy,
+             .helperBinaryNotFound,
+             .diagnosticError:
+            break
+        }
+    }
+
     /// Create or reuse an NSXPCConnection to the helper's Mach service.
     private func getProxy() throws -> any RockxyHelperProtocol {
+        try signingPreflight()
         let conn: NSXPCConnection
         if let existing = connection {
             conn = existing

--- a/Rockxy/Core/ProxyEngine/HelperManager.swift
+++ b/Rockxy/Core/ProxyEngine/HelperManager.swift
@@ -22,6 +22,27 @@ final class HelperManager {
         case installedOutdated
         case installedIncompatible
         case unreachable
+        case signingMismatch
+    }
+
+    /// Identifies the specific signing issue when status is `.signingMismatch`.
+    enum SigningIssue: Equatable {
+        case appSignatureInvalid(detail: String)
+        case identityMismatch(appSigner: String, helperSigner: String)
+    }
+
+    /// Normalized result from a helper info probe, scoped to the actual error surface.
+    enum ProbeOutcome: Equatable {
+        case appSignatureInvalid(detail: String)
+        case signingIdentityMismatch(appSigner: String, helperSigner: String)
+        case xpcFailure
+    }
+
+    /// Recovery action determined from a probe outcome.
+    enum RecoveryAction: Equatable {
+        case surfaceAppSignatureInvalid(detail: String)
+        case surfaceSigningMismatch(appSigner: String, helperSigner: String)
+        case attemptReRegistration
     }
 
     enum InstallDisposition: Equatable {
@@ -32,12 +53,20 @@ final class HelperManager {
 
     static let shared = HelperManager()
 
-    private(set) var status: HelperStatus = .notInstalled
+    private(set) var signingIssue: SigningIssue?
     private(set) var installedInfo: HelperInfo?
     private(set) var isReachable: Bool = false
     private(set) var lastErrorMessage: String?
     private(set) var isBusy: Bool = false
     private(set) var registrationStatus: String = "Unknown"
+
+    private(set) var status: HelperStatus = .notInstalled {
+        didSet {
+            if status != .signingMismatch {
+                signingIssue = nil
+            }
+        }
+    }
 
     var bundledHelperVersion: String {
         Bundle.main.infoDictionary?["RockxyBundledHelperVersion"] as? String ?? "0.0.0"
@@ -92,14 +121,105 @@ final class HelperManager {
         return helperApprovalMessage
     }
 
+    /// Classify a probe-path `HelperConnectionError` into a normalized outcome.
+    /// Only maps the error cases that actually occur on the probe path
+    /// (`getProxy()` → `getHelperInfo()`).
+    nonisolated static func classifyProbeError(_ error: HelperConnectionError) -> ProbeOutcome {
+        switch error {
+        case let .appSignatureInvalid(detail):
+            .appSignatureInvalid(detail: detail)
+        case let .signingIdentityMismatch(app, helper):
+            .signingIdentityMismatch(appSigner: app, helperSigner: helper)
+        default:
+            .xpcFailure
+        }
+    }
+
+    /// Determine recovery action from a normalized probe outcome.
+    nonisolated static func decideRecovery(probe: ProbeOutcome) -> RecoveryAction {
+        switch probe {
+        case let .appSignatureInvalid(detail):
+            .surfaceAppSignatureInvalid(detail: detail)
+        case let .signingIdentityMismatch(app, helper):
+            .surfaceSigningMismatch(appSigner: app, helperSigner: helper)
+        case .xpcFailure:
+            .attemptReRegistration
+        }
+    }
+
+    /// Action label for the helper step in Welcome and Settings views.
+    /// Returns `nil` when no action button should be shown.
+    nonisolated static func helperActionLabel(
+        status: HelperStatus,
+        signingIssue: SigningIssue?
+    )
+        -> String?
+    {
+        switch status {
+        case .installedCompatible:
+            nil
+        case .installedOutdated,
+             .installedIncompatible:
+            String(localized: "Update")
+        case .notInstalled:
+            String(localized: "Install")
+        case .requiresApproval:
+            String(localized: "Open Settings")
+        case .unreachable:
+            String(localized: "Retry")
+        case .signingMismatch:
+            switch signingIssue {
+            case .appSignatureInvalid:
+                nil
+            case .identityMismatch:
+                String(localized: "Reinstall")
+            case nil:
+                nil
+            }
+        }
+    }
+
+    /// Warning reason text for the signing mismatch case in readiness warnings.
+    nonisolated static func signingMismatchWarningReason(issue: SigningIssue?) -> String {
+        switch issue {
+        case .appSignatureInvalid:
+            String(
+                localized: "this app build has an invalid code signature \u{2014} clean the build folder and rebuild"
+            )
+        case .identityMismatch:
+            String(
+                localized: "the installed helper was signed by a different Rockxy build \u{2014} reinstall it from the current build"
+            )
+        case nil:
+            String(localized: "the helper tool has a signing issue")
+        }
+    }
+
+    /// Detect whether any helper state property changed, including `signingIssue`.
+    nonisolated static func helperStateDidChange(
+        previousStatus: HelperStatus, currentStatus: HelperStatus,
+        previousReachable: Bool, currentReachable: Bool,
+        previousInfo: HelperInfo?, currentInfo: HelperInfo?,
+        previousSigningIssue: SigningIssue?, currentSigningIssue: SigningIssue?
+    )
+        -> Bool
+    {
+        currentStatus != previousStatus
+            || currentReachable != previousReachable
+            || currentInfo != previousInfo
+            || currentSigningIssue != previousSigningIssue
+    }
+
     /// Register the helper daemon via SMAppService.
     ///
     /// On macOS 13+, this uses `SMAppService.daemon(plistName:).register()` which
     /// requires user approval in System Settings > Login Items.
     func install() async throws {
+        HelperConnection.shared.invalidateSigningCache()
         let previousStatus = status
         let previousReachable = isReachable
         let previousInfo = installedInfo
+        let previousSigningIssue = signingIssue
         lastErrorMessage = nil
         isBusy = true
         defer {
@@ -107,7 +227,8 @@ final class HelperManager {
             postStatusChangeIfNeeded(
                 previousStatus: previousStatus,
                 previousReachable: previousReachable,
-                previousInfo: previousInfo
+                previousInfo: previousInfo,
+                previousSigningIssue: previousSigningIssue
             )
         }
         try performInstall()
@@ -118,9 +239,11 @@ final class HelperManager {
 
     /// Uninstall the helper by preparing it via XPC, then unregistering from launchd.
     func uninstall() async throws {
+        HelperConnection.shared.invalidateSigningCache()
         let previousStatus = status
         let previousReachable = isReachable
         let previousInfo = installedInfo
+        let previousSigningIssue = signingIssue
         lastErrorMessage = nil
         isBusy = true
         defer {
@@ -128,7 +251,8 @@ final class HelperManager {
             postStatusChangeIfNeeded(
                 previousStatus: previousStatus,
                 previousReachable: previousReachable,
-                previousInfo: previousInfo
+                previousInfo: previousInfo,
+                previousSigningIssue: previousSigningIssue
             )
         }
         try await performUninstall()
@@ -136,9 +260,11 @@ final class HelperManager {
 
     /// Check whether the helper is installed, responding, and at the correct version.
     func checkStatus() async {
+        HelperConnection.shared.invalidateSigningCache()
         let previousStatus = status
         let previousReachable = isReachable
         let previousInfo = installedInfo
+        let previousSigningIssue = signingIssue
         lastErrorMessage = nil
         isBusy = true
         defer {
@@ -146,7 +272,8 @@ final class HelperManager {
             postStatusChangeIfNeeded(
                 previousStatus: previousStatus,
                 previousReachable: previousReachable,
-                previousInfo: previousInfo
+                previousInfo: previousInfo,
+                previousSigningIssue: previousSigningIssue
             )
         }
         await performCheckStatus()
@@ -156,9 +283,11 @@ final class HelperManager {
     /// After unregistering, BTM trust is cleared so re-registration may require
     /// user approval in System Settings > Login Items.
     func update() async throws {
+        HelperConnection.shared.invalidateSigningCache()
         let previousStatus = status
         let previousReachable = isReachable
         let previousInfo = installedInfo
+        let previousSigningIssue = signingIssue
         lastErrorMessage = nil
         isBusy = true
         defer {
@@ -166,7 +295,8 @@ final class HelperManager {
             postStatusChangeIfNeeded(
                 previousStatus: previousStatus,
                 previousReachable: previousReachable,
-                previousInfo: previousInfo
+                previousInfo: previousInfo,
+                previousSigningIssue: previousSigningIssue
             )
         }
 
@@ -193,9 +323,11 @@ final class HelperManager {
 
     /// Retry establishing connection with the helper.
     func retryConnection() async {
+        HelperConnection.shared.invalidateSigningCache()
         let previousStatus = status
         let previousReachable = isReachable
         let previousInfo = installedInfo
+        let previousSigningIssue = signingIssue
         lastErrorMessage = nil
         isBusy = true
         defer {
@@ -203,7 +335,8 @@ final class HelperManager {
             postStatusChangeIfNeeded(
                 previousStatus: previousStatus,
                 previousReachable: previousReachable,
-                previousInfo: previousInfo
+                previousInfo: previousInfo,
+                previousSigningIssue: previousSigningIssue
             )
         }
         HelperConnection.shared.resetConnection()
@@ -212,9 +345,11 @@ final class HelperManager {
 
     /// Reinstall the helper by uninstalling, then installing fresh.
     func reinstall() async throws {
+        HelperConnection.shared.invalidateSigningCache()
         let previousStatus = status
         let previousReachable = isReachable
         let previousInfo = installedInfo
+        let previousSigningIssue = signingIssue
         lastErrorMessage = nil
         isBusy = true
         defer {
@@ -222,7 +357,8 @@ final class HelperManager {
             postStatusChangeIfNeeded(
                 previousStatus: previousStatus,
                 previousReachable: previousReachable,
-                previousInfo: previousInfo
+                previousInfo: previousInfo,
+                previousSigningIssue: previousSigningIssue
             )
         }
         do {
@@ -236,6 +372,90 @@ final class HelperManager {
             throw error
         }
     }
+
+    /// Force-reset the helper registration to recover from BTM desync.
+    ///
+    /// When macOS Background Task Management gets into a stuck state where
+    /// `SMAppService` reports `.requiresApproval` but toggling the System Settings
+    /// switch has no effect, this method clears the registration and re-registers
+    /// with a longer delay to allow BTM to settle.
+    func forceResetRegistration() async throws {
+        HelperConnection.shared.invalidateSigningCache()
+        let previousStatus = status
+        let previousReachable = isReachable
+        let previousInfo = installedInfo
+        let previousSigningIssue = signingIssue
+        lastErrorMessage = nil
+        isBusy = true
+        defer {
+            isBusy = false
+            postStatusChangeIfNeeded(
+                previousStatus: previousStatus,
+                previousReachable: previousReachable,
+                previousInfo: previousInfo,
+                previousSigningIssue: previousSigningIssue
+            )
+        }
+
+        Self.logger.info("Force-resetting helper registration to recover from BTM desync")
+        let service = SMAppService.daemon(plistName: Self.plistName)
+
+        do {
+            try await service.unregister()
+        } catch {
+            Self.logger.warning("Unregister during force-reset: \(error.localizedDescription)")
+        }
+
+        status = .notInstalled
+        installedInfo = nil
+        isReachable = false
+        registrationStatus = "Not Registered"
+        HelperConnection.shared.resetConnection()
+
+        try? await Task.sleep(nanoseconds: 3_000_000_000)
+
+        do {
+            try performInstall()
+            if status != .requiresApproval {
+                await performCheckStatus()
+            }
+        } catch {
+            lastErrorMessage = error.localizedDescription
+            throw error
+        }
+    }
+
+    // MARK: - Test Support
+
+    #if DEBUG
+    /// Inject a full helper state snapshot and route through the real
+    /// change-detection / notification emission pipeline.
+    func injectHelperStateForTests(
+        status: HelperStatus,
+        signingIssue: SigningIssue?,
+        isReachable: Bool = false,
+        installedInfo: HelperInfo? = nil,
+        lastErrorMessage: String? = nil
+    ) {
+        let previousStatus = self.status
+        let previousReachable = self.isReachable
+        let previousInfo = self.installedInfo
+        let previousSigningIssue = self.signingIssue
+
+        self.installedInfo = installedInfo
+        self.isReachable = isReachable
+        self.lastErrorMessage = lastErrorMessage
+        self.signingIssue = signingIssue
+        self.status = status
+
+        postStatusChangeIfNeeded(
+            previousStatus: previousStatus,
+            previousReachable: previousReachable,
+            previousInfo: previousInfo,
+            previousSigningIssue: previousSigningIssue
+        )
+    }
+    #endif
 
     // MARK: Private
 
@@ -253,11 +473,15 @@ final class HelperManager {
     private func postStatusChangeIfNeeded(
         previousStatus: HelperStatus,
         previousReachable: Bool,
-        previousInfo: HelperInfo?
+        previousInfo: HelperInfo?,
+        previousSigningIssue: SigningIssue?
     ) {
-        let changed = status != previousStatus
-            || isReachable != previousReachable
-            || installedInfo != previousInfo
+        let changed = Self.helperStateDidChange(
+            previousStatus: previousStatus, currentStatus: status,
+            previousReachable: previousReachable, currentReachable: isReachable,
+            previousInfo: previousInfo, currentInfo: installedInfo,
+            previousSigningIssue: previousSigningIssue, currentSigningIssue: signingIssue
+        )
         if changed {
             NotificationCenter.default.post(name: .helperStatusChanged, object: nil)
         }
@@ -338,6 +562,7 @@ final class HelperManager {
             status = .notInstalled
             installedInfo = nil
             isReachable = false
+            registrationStatus = "Not Registered"
             Self.logger.info("Helper tool uninstalled")
         } catch {
             lastErrorMessage = error.localizedDescription
@@ -385,8 +610,7 @@ final class HelperManager {
 
     /// Handle the case where SMAppService reports the helper as enabled.
     /// Checks XPC reachability, then evaluates protocol-aware compatibility.
-    /// Best-effort heuristic: XPC call failure → `.installedIncompatible`,
-    /// connection failure → `.unreachable`.
+    /// Signing-related failures are surfaced immediately without re-registration attempts.
     private func checkEnabledHelper(service: SMAppService) async {
         do {
             let info = try await probeHelperInfo()
@@ -394,34 +618,84 @@ final class HelperManager {
             isReachable = true
             lastErrorMessage = nil
             status = evaluateCompatibility(info)
+        } catch let error as HelperConnectionError {
+            let probe = Self.classifyProbeError(error)
+            let action = Self.decideRecovery(probe: probe)
+
+            switch action {
+            case let .surfaceAppSignatureInvalid(detail):
+                setSigningMismatchState(.appSignatureInvalid(detail: detail))
+                return
+
+            case let .surfaceSigningMismatch(app, helper):
+                setSigningMismatchState(.identityMismatch(appSigner: app, helperSigner: helper))
+                return
+
+            case .attemptReRegistration:
+                Self.logger.info(
+                    "Helper registered but not responding (\(error.localizedDescription)) — attempting re-registration"
+                )
+                do {
+                    guard try await reRegister(service: service) else {
+                        return
+                    }
+                    do {
+                        let info = try await probeHelperInfo()
+                        installedInfo = info
+                        isReachable = true
+                        lastErrorMessage = nil
+                        status = evaluateCompatibility(info)
+                    } catch let retryError as HelperConnectionError {
+                        let retryProbe = Self.classifyProbeError(retryError)
+                        let retryAction = Self.decideRecovery(probe: retryProbe)
+                        switch retryAction {
+                        case let .surfaceAppSignatureInvalid(detail):
+                            setSigningMismatchState(.appSignatureInvalid(detail: detail))
+                        case let .surfaceSigningMismatch(app, helper):
+                            setSigningMismatchState(.identityMismatch(appSigner: app, helperSigner: helper))
+                        case .attemptReRegistration:
+                            Self.logger.warning(
+                                "Helper still not responding after re-registration: \(retryError.localizedDescription)"
+                            )
+                            installedInfo = nil
+                            isReachable = false
+                            lastErrorMessage = String(
+                                localized: "Helper is installed but incompatible or unreachable. Try reinstalling the helper tool."
+                            )
+                            status = .installedIncompatible
+                        }
+                    } catch {
+                        Self.logger.warning(
+                            "Helper still not responding after re-registration: \(error.localizedDescription)"
+                        )
+                        installedInfo = nil
+                        isReachable = false
+                        lastErrorMessage = String(
+                            localized: "Helper is installed but incompatible or unreachable. Try reinstalling the helper tool."
+                        )
+                        status = .installedIncompatible
+                    }
+                } catch {
+                    Self.logger.warning("Re-registration failed: \(error.localizedDescription)")
+                    installedInfo = nil
+                    isReachable = false
+                    lastErrorMessage = error.localizedDescription
+                    status = .unreachable
+                }
+            }
         } catch {
             Self.logger.info(
                 "Helper registered but not responding (\(error.localizedDescription)) — attempting re-registration"
             )
             do {
-                try await service.unregister()
-                try? await Task.sleep(nanoseconds: 2_000_000_000)
-                try service.register()
-                try? await Task.sleep(nanoseconds: 2_000_000_000)
-                HelperConnection.shared.resetConnection()
-
-                do {
-                    let info = try await probeHelperInfo()
-                    installedInfo = info
-                    isReachable = true
-                    lastErrorMessage = nil
-                    status = evaluateCompatibility(info)
-                } catch {
-                    Self.logger.warning(
-                        "Helper still not responding after re-registration: \(error.localizedDescription)"
-                    )
-                    installedInfo = nil
-                    isReachable = false
-                    lastErrorMessage = String(
-                        localized: "Helper is installed but incompatible or unreachable. Try reinstalling the helper tool."
-                    )
-                    status = .installedIncompatible
+                guard try await reRegister(service: service) else {
+                    return
                 }
+                let info = try await probeHelperInfo()
+                installedInfo = info
+                isReachable = true
+                lastErrorMessage = nil
+                status = evaluateCompatibility(info)
             } catch {
                 Self.logger.warning("Re-registration failed: \(error.localizedDescription)")
                 installedInfo = nil
@@ -430,6 +704,69 @@ final class HelperManager {
                 status = .unreachable
             }
         }
+    }
+
+    /// Centralized state setter for signing mismatch conditions.
+    private func setSigningMismatchState(_ issue: SigningIssue) {
+        installedInfo = nil
+        isReachable = false
+        signingIssue = issue
+        switch issue {
+        case let .appSignatureInvalid(detail):
+            lastErrorMessage = String(
+                localized: """
+                This app build has an invalid code signature (\(detail)). \
+                Clean the build folder (Product \u{2192} Clean Build Folder) and rebuild, \
+                or use the release version of Rockxy.
+                """
+            )
+        case let .identityMismatch(app, helper):
+            lastErrorMessage = String(
+                localized: """
+                This app is signed by \u{201C}\(app)\u{201D} but the installed helper expects \
+                \u{201C}\(helper)\u{201D}. Reinstall the helper from the current build, \
+                or run the matching release version.
+                """
+            )
+        }
+        status = .signingMismatch
+    }
+
+    /// Attempt to re-register the helper via SMAppService, handling the case where
+    /// the new registration requires Login Items approval. Returns `true` if the
+    /// service is now enabled and probing should proceed, or `false` if approval is
+    /// required and the caller should stop the retry path.
+    private func reRegister(service: SMAppService) async throws -> Bool {
+        try await service.unregister()
+        try? await Task.sleep(nanoseconds: 2_000_000_000)
+
+        do {
+            try service.register()
+        } catch {
+            if Self.requiresApproval(error: error, serviceStatus: service.status) {
+                Self.logger.info("Re-registration requires user approval in System Settings")
+                status = .requiresApproval
+                registrationStatus = "Awaiting Approval"
+                lastErrorMessage = Self.approvalMessage(error: error, serviceStatus: service.status)
+                SMAppService.openSystemSettingsLoginItems()
+                return false
+            }
+            throw error
+        }
+
+        let currentStatus = service.status
+        if currentStatus == .requiresApproval {
+            Self.logger.info("Re-registered helper requires user approval in System Settings")
+            status = .requiresApproval
+            registrationStatus = "Awaiting Approval"
+            lastErrorMessage = Self.helperApprovalMessage
+            SMAppService.openSystemSettingsLoginItems()
+            return false
+        }
+
+        try? await Task.sleep(nanoseconds: 2_000_000_000)
+        HelperConnection.shared.resetConnection()
+        return true
     }
 
     /// Evaluate helper compatibility based on protocol version and build number.

--- a/Rockxy/Core/ProxyEngine/SigningDiagnostics.swift
+++ b/Rockxy/Core/ProxyEngine/SigningDiagnostics.swift
@@ -1,0 +1,218 @@
+import Foundation
+import os
+import Security
+
+/// App-side signing diagnostics that detect certificate mismatches between the
+/// running app and the installed helper binary BEFORE attempting XPC communication.
+///
+/// Two layers for testability:
+/// 1. `Environment` protocol abstracts Security framework calls.
+/// 2. `classify(_:)` is a pure function that maps environment observations to a result.
+enum SigningDiagnostics {
+    // MARK: Internal
+
+    // MARK: - Result
+
+    enum Result: Equatable {
+        /// App signature is valid, helper exists, certificate chains match.
+        case healthy
+        /// App bundle code signature is invalid (e.g., missing dylib after stale Xcode build).
+        case appSignatureInvalid(detail: String)
+        /// App is valid, helper binary exists, but signing identities differ.
+        case signingIdentityMismatch(appSigner: String, helperSigner: String)
+        /// App is valid, but no helper binary exists at the expected path.
+        case helperBinaryNotFound
+        /// An unexpected error occurred during diagnosis.
+        case diagnosticError(detail: String)
+    }
+
+    // MARK: - Environment
+
+    protocol Environment {
+        /// Validate the current app bundle's code signature.
+        /// Returns `nil` if valid, or an error description if invalid.
+        func validateAppSignature() -> String?
+        /// Check whether the helper binary exists at the expected path.
+        func helperBinaryExists() -> Bool
+        /// Extract leaf certificate subject summary from the running app.
+        func appSignerSummary() -> String?
+        /// Extract leaf certificate subject summary from the installed helper binary.
+        func helperSignerSummary() -> String?
+        /// Extract full DER certificate chain from the running app.
+        func appCertificateChain() -> [Data]?
+        /// Extract full DER certificate chain from the installed helper binary.
+        func helperCertificateChain() -> [Data]?
+    }
+
+    // MARK: - Live Environment
+
+    struct LiveEnvironment: Environment {
+        // MARK: Internal
+
+        func validateAppSignature() -> String? {
+            var code: SecCode?
+            guard SecCodeCopySelf([], &code) == errSecSuccess, let selfCode = code else {
+                return "SecCodeCopySelf failed"
+            }
+            var staticCode: SecStaticCode?
+            guard SecCodeCopyStaticCode(selfCode, [], &staticCode) == errSecSuccess,
+                  let selfStatic = staticCode else
+            {
+                return "SecCodeCopyStaticCode failed"
+            }
+            let status = SecStaticCodeCheckValidity(selfStatic, SecCSFlags([]), nil)
+            if status != errSecSuccess {
+                let desc = SecCopyErrorMessageString(status, nil) as String? ?? "unknown"
+                return "Code signature invalid: OSStatus \(status) (\(desc))"
+            }
+            return nil
+        }
+
+        func helperBinaryExists() -> Bool {
+            FileManager.default.fileExists(atPath: helperPath)
+        }
+
+        func appSignerSummary() -> String? {
+            guard let chain = appCertificateChain(), let leafDER = chain.first else {
+                return nil
+            }
+            return summaryFromDER(leafDER)
+        }
+
+        func helperSignerSummary() -> String? {
+            guard let chain = helperCertificateChain(), let leafDER = chain.first else {
+                return nil
+            }
+            return summaryFromDER(leafDER)
+        }
+
+        func appCertificateChain() -> [Data]? {
+            certificateChainForSelf()
+        }
+
+        func helperCertificateChain() -> [Data]? {
+            certificateChainForPath(helperPath)
+        }
+
+        // MARK: Private
+
+        private let helperPath =
+            "/Library/PrivilegedHelperTools/\(RockxyIdentity.current.helperBundleIdentifier)"
+
+        private func certificateChainForSelf() -> [Data]? {
+            var code: SecCode?
+            guard SecCodeCopySelf([], &code) == errSecSuccess, let selfCode = code else {
+                return nil
+            }
+            var staticCode: SecStaticCode?
+            guard SecCodeCopyStaticCode(selfCode, [], &staticCode) == errSecSuccess,
+                  let sc = staticCode else
+            {
+                return nil
+            }
+            return extractCertificateDERs(from: sc)
+        }
+
+        private func certificateChainForPath(_ path: String) -> [Data]? {
+            let url = URL(fileURLWithPath: path)
+            var staticCode: SecStaticCode?
+            guard SecStaticCodeCreateWithPath(url as CFURL, [], &staticCode) == errSecSuccess,
+                  let sc = staticCode else
+            {
+                return nil
+            }
+            return extractCertificateDERs(from: sc)
+        }
+
+        private func extractCertificateDERs(from staticCode: SecStaticCode) -> [Data]? {
+            var info: CFDictionary?
+            guard SecCodeCopySigningInformation(
+                staticCode,
+                SecCSFlags(rawValue: kSecCSSigningInformation),
+                &info
+            ) == errSecSuccess,
+                let dict = info as? [String: Any],
+                let certs = dict[kSecCodeInfoCertificates as String] as? [SecCertificate],
+                !certs.isEmpty else
+            {
+                return nil
+            }
+            return certs.map { SecCertificateCopyData($0) as Data }
+        }
+
+        private func summaryFromDER(_ der: Data) -> String? {
+            guard let cert = SecCertificateCreateWithData(nil, der as CFData) else {
+                return nil
+            }
+            return SecCertificateCopySubjectSummary(cert) as String?
+        }
+    }
+
+    // MARK: - Classification
+
+    /// Pure decision function. Maps environment observations to a diagnostic result.
+    static func classify(_ env: some Environment) -> Result {
+        if let invalidReason = env.validateAppSignature() {
+            return .appSignatureInvalid(detail: invalidReason)
+        }
+
+        guard env.helperBinaryExists() else {
+            return .helperBinaryNotFound
+        }
+
+        guard let appChain = env.appCertificateChain(),
+              let helperChain = env.helperCertificateChain() else
+        {
+            return .diagnosticError(
+                detail: "Failed to extract certificate chains for comparison"
+            )
+        }
+
+        guard appChain.count == helperChain.count else {
+            return .signingIdentityMismatch(
+                appSigner: env.appSignerSummary() ?? "unknown",
+                helperSigner: env.helperSignerSummary() ?? "unknown"
+            )
+        }
+
+        for index in appChain.indices {
+            if appChain[index] != helperChain[index] {
+                return .signingIdentityMismatch(
+                    appSigner: env.appSignerSummary() ?? "unknown",
+                    helperSigner: env.helperSignerSummary() ?? "unknown"
+                )
+            }
+        }
+
+        return .healthy
+    }
+
+    // MARK: - Convenience
+
+    /// Run diagnostics using the live Security framework environment.
+    static func diagnose() -> Result {
+        let result = classify(LiveEnvironment())
+        switch result {
+        case .healthy:
+            logger.debug("Signing diagnostics: healthy")
+        case let .appSignatureInvalid(detail):
+            logger.warning("Signing diagnostics: app signature invalid — \(detail)")
+        case let .signingIdentityMismatch(app, helper):
+            logger.warning(
+                "Signing diagnostics: identity mismatch — app=\(app) helper=\(helper)"
+            )
+        case .helperBinaryNotFound:
+            logger.debug("Signing diagnostics: helper binary not found")
+        case let .diagnosticError(detail):
+            logger.error("Signing diagnostics: error — \(detail)")
+        }
+        return result
+    }
+
+    // MARK: Private
+
+    private static let logger = Logger(
+        subsystem: RockxyIdentity.current.logSubsystem,
+        category: "SigningDiagnostics"
+    )
+}

--- a/Rockxy/Core/Services/ReadinessCoordinator.swift
+++ b/Rockxy/Core/Services/ReadinessCoordinator.swift
@@ -87,6 +87,7 @@ final class ReadinessCoordinator {
 
     private(set) var certReadiness: CertReadiness = .notGenerated
     private(set) var helperReadiness: HelperManager.HelperStatus = .notInstalled
+    private(set) var helperSigningIssue: HelperManager.SigningIssue?
     private(set) var proxyMode: ProxyMode = .unavailable
     private(set) var activeWarning: ReadinessWarning?
     private(set) var isCaptureActive: Bool = false
@@ -352,6 +353,7 @@ final class ReadinessCoordinator {
 
     private func refreshHelperState() {
         helperReadiness = HelperManager.shared.status
+        helperSigningIssue = HelperManager.shared.signingIssue
     }
 
     private func refreshProxyMode(isEnabled: Bool) {
@@ -470,6 +472,8 @@ final class ReadinessCoordinator {
             String(localized: "the helper tool is unreachable")
         case .installedCompatible:
             String(localized: "the helper tool could not be used")
+        case .signingMismatch:
+            HelperManager.signingMismatchWarningReason(issue: helperSigningIssue)
         }
 
         return ReadinessWarning(

--- a/Rockxy/ViewModels/WelcomeViewModel.swift
+++ b/Rockxy/ViewModels/WelcomeViewModel.swift
@@ -13,6 +13,7 @@ final class WelcomeViewModel {
     var certInstalled = false
     var certTrusted = false
     var helperStatus: HelperManager.HelperStatus = .notInstalled
+    var helperSigningIssue: HelperManager.SigningIssue?
     var systemProxyEnabled = false
     var isPerformingAction = false
     var errorMessage: String?
@@ -88,6 +89,51 @@ final class WelcomeViewModel {
         }
     }
 
+    func applyHelperState(
+        status: HelperManager.HelperStatus,
+        signingIssue: HelperManager.SigningIssue?
+    ) {
+        helperStatus = status
+        helperSigningIssue = signingIssue
+    }
+
+    func retryHelperConnection() async {
+        isPerformingAction = true
+        errorMessage = nil
+        defer { isPerformingAction = false }
+
+        await HelperManager.shared.retryConnection()
+        await refreshStatus()
+    }
+
+    func forceResetHelper() async {
+        isPerformingAction = true
+        errorMessage = nil
+        defer { isPerformingAction = false }
+
+        do {
+            try await HelperManager.shared.forceResetRegistration()
+            await refreshStatus()
+        } catch {
+            Self.logger.error("Failed to force-reset helper: \(error.localizedDescription)")
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func reinstallHelper() async {
+        isPerformingAction = true
+        errorMessage = nil
+        defer { isPerformingAction = false }
+
+        do {
+            try await HelperManager.shared.reinstall()
+            await refreshStatus()
+        } catch {
+            Self.logger.error("Failed to reinstall helper: \(error.localizedDescription)")
+            errorMessage = error.localizedDescription
+        }
+    }
+
     func updateHelper() async {
         isPerformingAction = true
         errorMessage = nil
@@ -124,7 +170,7 @@ final class WelcomeViewModel {
     private func apply(readiness: ReadinessCoordinator) {
         certInstalled = readiness.certReadiness != .notGenerated
         certTrusted = readiness.canInterceptHTTPS
-        helperStatus = readiness.helperReadiness
+        applyHelperState(status: readiness.helperReadiness, signingIssue: readiness.helperSigningIssue)
         systemProxyEnabled = SystemProxyManager.shared.isSystemProxyEnabled()
     }
 }

--- a/Rockxy/Views/Settings/AdvancedProxySettingsView.swift
+++ b/Rockxy/Views/Settings/AdvancedProxySettingsView.swift
@@ -86,6 +86,12 @@ struct AdvancedProxySettingsView: View {
             "arrow.triangle.2.circlepath.circle.fill"
         case .unreachable:
             "xmark.circle.fill"
+        case .signingMismatch:
+            if case .appSignatureInvalid = helperManager.signingIssue {
+                "xmark.seal.fill"
+            } else {
+                "exclamationmark.triangle.fill"
+            }
         }
     }
 
@@ -102,6 +108,12 @@ struct AdvancedProxySettingsView: View {
             .yellow
         case .unreachable:
             .red
+        case .signingMismatch:
+            if case .appSignatureInvalid = helperManager.signingIssue {
+                .red
+            } else {
+                .orange
+            }
         }
     }
 
@@ -119,6 +131,12 @@ struct AdvancedProxySettingsView: View {
             String(localized: "Incompatible Version")
         case .unreachable:
             String(localized: "Installed But Unreachable")
+        case .signingMismatch:
+            if case .appSignatureInvalid = helperManager.signingIssue {
+                String(localized: "Invalid App Signature")
+            } else {
+                String(localized: "Signing Mismatch")
+            }
         }
     }
 
@@ -136,6 +154,9 @@ struct AdvancedProxySettingsView: View {
             String(localized: "Installed helper is incompatible with this app version.")
         case .unreachable:
             String(localized: "Rockxy could not communicate with the helper over XPC.")
+        case .signingMismatch:
+            helperManager.lastErrorMessage
+                ?? String(localized: "The app and helper have mismatched signing certificates.")
         }
     }
 
@@ -412,6 +433,19 @@ struct AdvancedProxySettingsView: View {
                 }
                 .disabled(helperManager.isBusy)
 
+                Button(String(localized: "Reset Registration")) {
+                    Task {
+                        do {
+                            try await helperManager.forceResetRegistration()
+                        } catch {
+                            Self.logger.error(
+                                "Failed to force-reset helper: \(error.localizedDescription)"
+                            )
+                        }
+                    }
+                }
+                .disabled(helperManager.isBusy)
+
             case .installedCompatible:
                 Button(String(localized: "Check Again")) {
                     Task { await helperManager.checkStatus() }
@@ -450,6 +484,24 @@ struct AdvancedProxySettingsView: View {
                     showingUninstallConfirmation = true
                 }
                 .disabled(helperManager.isBusy)
+
+            case .signingMismatch:
+                if case .identityMismatch = helperManager.signingIssue {
+                    Button(String(localized: "Reinstall Helper")) {
+                        reinstallHelper()
+                    }
+                    .disabled(helperManager.isBusy)
+
+                    Button(String(localized: "Uninstall")) {
+                        showingUninstallConfirmation = true
+                    }
+                    .disabled(helperManager.isBusy)
+                } else {
+                    Button(String(localized: "Check Again")) {
+                        Task { await helperManager.checkStatus() }
+                    }
+                    .disabled(helperManager.isBusy)
+                }
             }
         }
     }

--- a/Rockxy/Views/Settings/AdvancedSettingsTab.swift
+++ b/Rockxy/Views/Settings/AdvancedSettingsTab.swift
@@ -107,6 +107,18 @@ struct AdvancedSettingsTab: View {
                                     Task { await helperManager.checkStatus() }
                                 }
                                 .disabled(helperManager.isBusy)
+                                Button(String(localized: "Reset Registration")) {
+                                    Task {
+                                        do {
+                                            try await helperManager.forceResetRegistration()
+                                        } catch {
+                                            Self.logger.error(
+                                                "Failed to force-reset helper: \(error.localizedDescription)"
+                                            )
+                                        }
+                                    }
+                                }
+                                .disabled(helperManager.isBusy)
                             case .installedCompatible:
                                 Button(String(localized: "Check Again")) {
                                     Task { await helperManager.checkStatus() }
@@ -139,6 +151,22 @@ struct AdvancedSettingsTab: View {
                                     showUninstallConfirmation = true
                                 }
                                 .disabled(helperManager.isBusy)
+                            case .signingMismatch:
+                                if case .identityMismatch = helperManager.signingIssue {
+                                    Button(String(localized: "Reinstall Helper")) {
+                                        reinstallHelper()
+                                    }
+                                    .disabled(helperManager.isBusy)
+                                    Button(String(localized: "Uninstall")) {
+                                        showUninstallConfirmation = true
+                                    }
+                                    .disabled(helperManager.isBusy)
+                                } else {
+                                    Button(String(localized: "Check Again")) {
+                                        Task { await helperManager.checkStatus() }
+                                    }
+                                    .disabled(helperManager.isBusy)
+                                }
                             }
                         }
                     }
@@ -216,6 +244,12 @@ struct AdvancedSettingsTab: View {
             "arrow.triangle.2.circlepath.circle.fill"
         case .unreachable:
             "xmark.circle.fill"
+        case .signingMismatch:
+            if case .appSignatureInvalid = helperManager.signingIssue {
+                "xmark.seal.fill"
+            } else {
+                "exclamationmark.triangle.fill"
+            }
         }
     }
 
@@ -232,6 +266,12 @@ struct AdvancedSettingsTab: View {
             .yellow
         case .unreachable:
             .red
+        case .signingMismatch:
+            if case .appSignatureInvalid = helperManager.signingIssue {
+                .red
+            } else {
+                .orange
+            }
         }
     }
 
@@ -248,6 +288,12 @@ struct AdvancedSettingsTab: View {
             String(localized: "Update Available")
         case .unreachable:
             String(localized: "Unreachable")
+        case .signingMismatch:
+            if case .appSignatureInvalid = helperManager.signingIssue {
+                String(localized: "Invalid App Signature")
+            } else {
+                String(localized: "Signing Mismatch")
+            }
         }
     }
 
@@ -287,6 +333,9 @@ struct AdvancedSettingsTab: View {
             String(localized: "Installed helper version is incompatible with this app.")
         case .unreachable:
             String(localized: "Rockxy could not communicate with the helper over XPC.")
+        case .signingMismatch:
+            helperManager.lastErrorMessage
+                ?? String(localized: "The app and helper have mismatched signing certificates.")
         }
     }
 

--- a/Rockxy/Views/Welcome/WelcomeView.swift
+++ b/Rockxy/Views/Welcome/WelcomeView.swift
@@ -40,6 +40,9 @@ struct WelcomeView: View {
         .onChange(of: ReadinessCoordinator.shared.helperReadiness) {
             viewModel.syncFromCoordinator()
         }
+        .onChange(of: ReadinessCoordinator.shared.helperSigningIssue) {
+            viewModel.syncFromCoordinator()
+        }
         .onChange(of: ReadinessCoordinator.shared.proxyMode) {
             viewModel.syncFromCoordinator()
         }
@@ -85,6 +88,12 @@ struct WelcomeView: View {
                         .helperStatus == .installedIncompatible
                     {
                         await viewModel.updateHelper()
+                    } else if viewModel.helperStatus == .signingMismatch {
+                        if case .identityMismatch = viewModel.helperSigningIssue {
+                            await viewModel.reinstallHelper()
+                        }
+                    } else if viewModel.helperStatus == .unreachable {
+                        await viewModel.retryHelperConnection()
                     } else {
                         await viewModel.installHelper()
                     }
@@ -102,19 +111,10 @@ struct WelcomeView: View {
     }
 
     private var helperActionLabel: String? {
-        switch viewModel.helperStatus {
-        case .installedCompatible:
-            nil
-        case .installedOutdated,
-             .installedIncompatible:
-            String(localized: "Update")
-        case .notInstalled:
-            String(localized: "Install")
-        case .requiresApproval:
-            String(localized: "Open Settings")
-        case .unreachable:
-            String(localized: "Retry")
-        }
+        HelperManager.helperActionLabel(
+            status: viewModel.helperStatus,
+            signingIssue: viewModel.helperSigningIssue
+        )
     }
 
     private var appVersion: String {

--- a/RockxyHelperTool/ConnectionValidator.swift
+++ b/RockxyHelperTool/ConnectionValidator.swift
@@ -255,7 +255,10 @@ enum ConnectionValidator {
         )
 
         guard validityStatus == errSecSuccess else {
-            logger.error("SecStaticCodeCheckValidity failed for \(label): \(validityStatus)")
+            let statusDesc = SecCopyErrorMessageString(validityStatus, nil) as String? ?? "unknown"
+            logger.error(
+                "SecStaticCodeCheckValidity failed for \(label): OSStatus \(validityStatus) (\(statusDesc))"
+            )
             return nil
         }
 
@@ -299,7 +302,11 @@ enum ConnectionValidator {
             let rhsData = SecCertificateCopyData(rhs[index]) as Data
 
             if lhsData != rhsData {
-                logger.debug("Certificate mismatch at chain index \(index)")
+                let lhsSummary = SecCertificateCopySubjectSummary(lhs[index]) as String? ?? "unknown"
+                let rhsSummary = SecCertificateCopySubjectSummary(rhs[index]) as String? ?? "unknown"
+                logger.debug(
+                    "Certificate mismatch at index \(index): self=\"\(lhsSummary)\" caller=\"\(rhsSummary)\""
+                )
                 return false
             }
         }

--- a/RockxyTests/Core/ProxyEngine/HelperConnectionTests.swift
+++ b/RockxyTests/Core/ProxyEngine/HelperConnectionTests.swift
@@ -42,6 +42,22 @@ struct HelperConnectionErrorTests {
         #expect(description.contains("timed out"))
     }
 
+    @Test("appSignatureInvalid includes detail in description")
+    func appSignatureInvalidDescription() {
+        let error = HelperConnectionError.appSignatureInvalid("stale build")
+        let description = error.errorDescription ?? ""
+        #expect(description.contains("code signature"))
+        #expect(description.contains("stale build"))
+    }
+
+    @Test("signingIdentityMismatch includes signer names in description")
+    func signingIdentityMismatchDescription() {
+        let error = HelperConnectionError.signingIdentityMismatch(app: "Dev", helper: "Prod")
+        let description = error.errorDescription ?? ""
+        #expect(description.contains("Dev"))
+        #expect(description.contains("Prod"))
+    }
+
     @Test("All cases conform to LocalizedError with non-nil descriptions")
     func allCasesHaveDescriptions() {
         let cases: [HelperConnectionError] = [
@@ -50,6 +66,8 @@ struct HelperConnectionErrorTests {
             .proxyRestoreFailed("test"),
             .uninstallFailed,
             .xpcTimeout,
+            .appSignatureInvalid("test"),
+            .signingIdentityMismatch(app: "test", helper: "test"),
         ]
 
         for error in cases {

--- a/RockxyTests/Core/ProxyEngine/HelperManagerTests.swift
+++ b/RockxyTests/Core/ProxyEngine/HelperManagerTests.swift
@@ -70,4 +70,159 @@ struct HelperManagerTests {
 
         #expect(!HelperManager.requiresApproval(error: unrelatedError, serviceStatus: .notRegistered))
     }
+
+    // MARK: - Probe Error Classification
+
+    @Test("classifyProbeError maps appSignatureInvalid")
+    @MainActor
+    func classifyProbeErrorAppSignature() {
+        let probe = HelperManager.classifyProbeError(.appSignatureInvalid("stale build"))
+        #expect(probe == .appSignatureInvalid(detail: "stale build"))
+    }
+
+    @Test("classifyProbeError maps signingIdentityMismatch")
+    @MainActor
+    func classifyProbeErrorSigningMismatch() {
+        let probe = HelperManager.classifyProbeError(
+            .signingIdentityMismatch(app: "Dev", helper: "Prod")
+        )
+        #expect(probe == .signingIdentityMismatch(appSigner: "Dev", helperSigner: "Prod"))
+    }
+
+    @Test("classifyProbeError maps xpcTimeout to xpcFailure")
+    @MainActor
+    func classifyProbeErrorTimeout() {
+        let probe = HelperManager.classifyProbeError(.xpcTimeout)
+        #expect(probe == .xpcFailure)
+    }
+
+    @Test("classifyProbeError maps connectionFailed to xpcFailure")
+    @MainActor
+    func classifyProbeErrorConnectionFailed() {
+        let probe = HelperManager.classifyProbeError(.connectionFailed)
+        #expect(probe == .xpcFailure)
+    }
+
+    @Test("decideRecovery returns attemptReRegistration for xpcFailure")
+    @MainActor
+    func decideRecoveryXpcFailure() {
+        let action = HelperManager.decideRecovery(probe: .xpcFailure)
+        #expect(action == .attemptReRegistration)
+    }
+
+    // MARK: - Subtype-Only Change Detection
+
+    @Test("signing issue change without status change is detected")
+    @MainActor
+    func signingIssueOnlyChangeDetected() {
+        let changed = HelperManager.helperStateDidChange(
+            previousStatus: .signingMismatch, currentStatus: .signingMismatch,
+            previousReachable: false, currentReachable: false,
+            previousInfo: nil, currentInfo: nil,
+            previousSigningIssue: .appSignatureInvalid(detail: "stale"),
+            currentSigningIssue: .identityMismatch(appSigner: "Dev", helperSigner: "Prod")
+        )
+        #expect(changed == true)
+    }
+
+    @Test("identical signing issue is not a change")
+    @MainActor
+    func identicalSigningIssueNotChanged() {
+        let changed = HelperManager.helperStateDidChange(
+            previousStatus: .signingMismatch, currentStatus: .signingMismatch,
+            previousReachable: false, currentReachable: false,
+            previousInfo: nil, currentInfo: nil,
+            previousSigningIssue: .appSignatureInvalid(detail: "stale"),
+            currentSigningIssue: .appSignatureInvalid(detail: "stale")
+        )
+        #expect(changed == false)
+    }
+
+    // MARK: - Action Label and Warning Reason
+
+    @Test("appSignatureInvalid produces no action label")
+    @MainActor
+    func appSignatureInvalidNoActionLabel() {
+        let label = HelperManager.helperActionLabel(
+            status: .signingMismatch,
+            signingIssue: .appSignatureInvalid(detail: "stale")
+        )
+        #expect(label == nil)
+    }
+
+    @Test("identityMismatch produces reinstall action label")
+    @MainActor
+    func identityMismatchReinstallLabel() {
+        let label = HelperManager.helperActionLabel(
+            status: .signingMismatch,
+            signingIssue: .identityMismatch(appSigner: "Dev", helperSigner: "Prod")
+        )
+        #expect(label == String(localized: "Reinstall"))
+    }
+
+    @Test("installedCompatible produces no action label")
+    @MainActor
+    func installedCompatibleNoLabel() {
+        let label = HelperManager.helperActionLabel(
+            status: .installedCompatible,
+            signingIssue: nil
+        )
+        #expect(label == nil)
+    }
+
+    @Test("appSignatureInvalid warning mentions clean build")
+    func appSignatureInvalidWarning() {
+        let reason = HelperManager.signingMismatchWarningReason(
+            issue: .appSignatureInvalid(detail: "stale")
+        )
+        #expect(reason.localizedLowercase.contains("clean"))
+    }
+
+    @Test("identityMismatch warning mentions reinstall")
+    func identityMismatchWarning() {
+        let reason = HelperManager.signingMismatchWarningReason(
+            issue: .identityMismatch(appSigner: "Dev", helperSigner: "Prod")
+        )
+        #expect(reason.localizedLowercase.contains("reinstall"))
+    }
+
+    // MARK: - Re-registration Approval Detection
+
+    @Test("requiresApproval recognizes kSMErrorLaunchDeniedByUser during re-registration")
+    func reRegistrationApprovalDetected() {
+        let deniedError = NSError(domain: NSOSStatusErrorDomain, code: kSMErrorLaunchDeniedByUser)
+        #expect(HelperManager.requiresApproval(error: deniedError, serviceStatus: .requiresApproval))
+    }
+
+    @Test("approval message is user-facing for requiresApproval service state")
+    func reRegistrationApprovalMessage() {
+        let deniedError = NSError(domain: NSOSStatusErrorDomain, code: kSMErrorLaunchDeniedByUser)
+        let message = HelperManager.approvalMessage(error: deniedError, serviceStatus: .requiresApproval)
+        #expect(message.contains("System Settings"))
+        #expect(message.contains("Login Items"))
+    }
+
+    // MARK: - Uninstall Registration Status Reset
+
+    @Test("injecting notInstalled state resets registrationStatus via injectHelperStateForTests")
+    @MainActor
+    func uninstallResetsRegistrationStatus() {
+        let manager = HelperManager.shared
+
+        manager.injectHelperStateForTests(
+            status: .installedCompatible,
+            signingIssue: nil,
+            isReachable: true
+        )
+        #expect(manager.status == .installedCompatible)
+
+        manager.injectHelperStateForTests(
+            status: .notInstalled,
+            signingIssue: nil,
+            isReachable: false
+        )
+        #expect(manager.status == .notInstalled)
+        #expect(manager.isReachable == false)
+        #expect(manager.installedInfo == nil)
+    }
 }

--- a/RockxyTests/Core/ProxyEngine/SigningDiagnosticsTests.swift
+++ b/RockxyTests/Core/ProxyEngine/SigningDiagnosticsTests.swift
@@ -1,0 +1,195 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+// MARK: - MockSigningEnvironment
+
+private struct MockSigningEnvironment: SigningDiagnostics.Environment {
+    var appSignatureError: String?
+    var helperExists: Bool = true
+    var appSigner: String? = "Apple Development: dev@example.com"
+    var helperSigner: String? = "Developer ID Application: Dev Corp"
+    var appChain: [Data]? = [Data([1, 2, 3]), Data([4, 5, 6])]
+    var helperChain: [Data]? = [Data([1, 2, 3]), Data([4, 5, 6])]
+
+    func validateAppSignature() -> String? {
+        appSignatureError
+    }
+
+    func helperBinaryExists() -> Bool {
+        helperExists
+    }
+
+    func appSignerSummary() -> String? {
+        appSigner
+    }
+
+    func helperSignerSummary() -> String? {
+        helperSigner
+    }
+
+    func appCertificateChain() -> [Data]? {
+        appChain
+    }
+
+    func helperCertificateChain() -> [Data]? {
+        helperChain
+    }
+}
+
+// MARK: - SigningDiagnosticsClassifyTests
+
+struct SigningDiagnosticsClassifyTests {
+    @Test("app signature invalid returns appSignatureInvalid")
+    func appSignatureInvalid() {
+        var env = MockSigningEnvironment()
+        env.appSignatureError = "Code signature invalid (OSStatus -67054)"
+
+        let result = SigningDiagnostics.classify(env)
+
+        #expect(result == .appSignatureInvalid(
+            detail: "Code signature invalid (OSStatus -67054)"
+        ))
+    }
+
+    @Test("healthy when app valid and certificates match")
+    func healthyWhenMatch() {
+        let env = MockSigningEnvironment()
+
+        let result = SigningDiagnostics.classify(env)
+
+        #expect(result == .healthy)
+    }
+
+    @Test("signing identity mismatch when leaf certificate differs")
+    func signingIdentityMismatchLeaf() {
+        var env = MockSigningEnvironment()
+        env.helperChain = [Data([7, 8, 9]), Data([4, 5, 6])]
+
+        let result = SigningDiagnostics.classify(env)
+
+        #expect(result == .signingIdentityMismatch(
+            appSigner: "Apple Development: dev@example.com",
+            helperSigner: "Developer ID Application: Dev Corp"
+        ))
+    }
+
+    @Test("signing identity mismatch when chain lengths differ")
+    func chainLengthMismatch() {
+        var env = MockSigningEnvironment()
+        env.helperChain = [Data([1, 2, 3])]
+
+        let result = SigningDiagnostics.classify(env)
+
+        #expect(result == .signingIdentityMismatch(
+            appSigner: "Apple Development: dev@example.com",
+            helperSigner: "Developer ID Application: Dev Corp"
+        ))
+    }
+
+    @Test("helper binary not found returns helperBinaryNotFound")
+    func helperNotFound() {
+        var env = MockSigningEnvironment()
+        env.helperExists = false
+
+        let result = SigningDiagnostics.classify(env)
+
+        #expect(result == .helperBinaryNotFound)
+    }
+
+    @Test("diagnostic error when app chain extraction fails")
+    func diagnosticErrorAppChain() {
+        var env = MockSigningEnvironment()
+        env.appChain = nil
+
+        let result = SigningDiagnostics.classify(env)
+
+        #expect(result == .diagnosticError(
+            detail: "Failed to extract certificate chains for comparison"
+        ))
+    }
+
+    @Test("diagnostic error when helper chain extraction fails")
+    func diagnosticErrorHelperChain() {
+        var env = MockSigningEnvironment()
+        env.helperChain = nil
+
+        let result = SigningDiagnostics.classify(env)
+
+        #expect(result == .diagnosticError(
+            detail: "Failed to extract certificate chains for comparison"
+        ))
+    }
+
+    @Test("app signature check runs before helper existence check")
+    func appSignatureBeforeHelperCheck() {
+        var env = MockSigningEnvironment()
+        env.appSignatureError = "invalid"
+        env.helperExists = false
+
+        let result = SigningDiagnostics.classify(env)
+
+        #expect(result == .appSignatureInvalid(detail: "invalid"))
+    }
+
+    @Test("helper existence check runs before chain comparison")
+    func helperExistenceBeforeChainComparison() {
+        var env = MockSigningEnvironment()
+        env.helperExists = false
+        env.appChain = nil
+
+        let result = SigningDiagnostics.classify(env)
+
+        #expect(result == .helperBinaryNotFound)
+    }
+
+    @Test("mismatch result carries signer names")
+    func mismatchCarriesSignerNames() {
+        var env = MockSigningEnvironment()
+        env.appSigner = "Apple Development: test@dev.com"
+        env.helperSigner = "Developer ID Application: Prod Corp"
+        env.helperChain = [Data([99])]
+
+        let result = SigningDiagnostics.classify(env)
+
+        if case let .signingIdentityMismatch(app, helper) = result {
+            #expect(app == "Apple Development: test@dev.com")
+            #expect(helper == "Developer ID Application: Prod Corp")
+        } else {
+            Issue.record("Expected signingIdentityMismatch, got \(result)")
+        }
+    }
+}
+
+// MARK: - SigningPreflightCacheTests
+
+struct SigningPreflightCacheTests {
+    @Test("preflight cache invalidation triggers re-evaluation")
+    @MainActor
+    func preflightCacheInvalidation() {
+        let cache = SigningPreflightCache()
+        var callCount = 0
+
+        cache.provider = {
+            callCount += 1
+            if callCount == 1 {
+                return .signingIdentityMismatch(appSigner: "Dev", helperSigner: "Prod")
+            }
+            return .healthy
+        }
+
+        let first = cache.evaluate()
+        #expect(first == .signingIdentityMismatch(appSigner: "Dev", helperSigner: "Prod"))
+        #expect(callCount == 1)
+
+        let second = cache.evaluate()
+        #expect(second == .signingIdentityMismatch(appSigner: "Dev", helperSigner: "Prod"))
+        #expect(callCount == 1)
+
+        cache.invalidate()
+
+        let third = cache.evaluate()
+        #expect(third == .healthy)
+        #expect(callCount == 2)
+    }
+}

--- a/RockxyTests/Core/Services/ReadinessCoordinatorTests.swift
+++ b/RockxyTests/Core/Services/ReadinessCoordinatorTests.swift
@@ -187,6 +187,81 @@ struct ReadinessCoordinatorTests {
         #expect(coordinator.helperReadiness == HelperManager.shared.status)
     }
 
+    @Test("signing issue subtype change propagates through notification path")
+    @MainActor
+    func signingIssueSubtypeChangePropagates() async throws {
+        let coordinator = ReadinessCoordinator.shared
+        let manager = HelperManager.shared
+        coordinator.startObserving()
+
+        // Wrap assertions so cleanup always runs even on thrown errors.
+        var caughtError: (any Error)?
+        do {
+            // First state: signingMismatch + appSignatureInvalid
+            manager.injectHelperStateForTests(
+                status: .signingMismatch,
+                signingIssue: .appSignatureInvalid(detail: "stale")
+            )
+
+            for _ in 0 ..< 40 {
+                if coordinator.helperSigningIssue == .appSignatureInvalid(detail: "stale") {
+                    break
+                }
+                try await Task.sleep(for: .milliseconds(50))
+            }
+            #expect(coordinator.helperReadiness == .signingMismatch)
+            #expect(coordinator.helperSigningIssue == .appSignatureInvalid(detail: "stale"))
+
+            // Subtype-only change: same status, different issue
+            manager.injectHelperStateForTests(
+                status: .signingMismatch,
+                signingIssue: .identityMismatch(appSigner: "Dev", helperSigner: "Prod")
+            )
+
+            for _ in 0 ..< 40 {
+                if coordinator.helperSigningIssue == .identityMismatch(
+                    appSigner: "Dev",
+                    helperSigner: "Prod"
+                ) {
+                    break
+                }
+                try await Task.sleep(for: .milliseconds(50))
+            }
+            #expect(coordinator.helperReadiness == .signingMismatch)
+            #expect(
+                coordinator.helperSigningIssue == .identityMismatch(
+                    appSigner: "Dev",
+                    helperSigner: "Prod"
+                )
+            )
+        } catch {
+            caughtError = error
+        }
+
+        // Async cleanup: reset baseline and wait for the coordinator to reflect
+        // it before stopping the observer. Uses try? so cleanup itself cannot throw.
+        manager.injectHelperStateForTests(
+            status: .notInstalled,
+            signingIssue: nil,
+            isReachable: false,
+            installedInfo: nil,
+            lastErrorMessage: nil
+        )
+        for _ in 0 ..< 40 {
+            if coordinator.helperReadiness == .notInstalled,
+               coordinator.helperSigningIssue == nil
+            {
+                break
+            }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+        coordinator.stopObserving()
+
+        if let caughtError {
+            throw caughtError
+        }
+    }
+
     @Test("app-active refresh updates cert state without proxy start")
     @MainActor
     func appActiveRefreshUpdatesCertState() async throws {

--- a/RockxyTests/ViewModels/WelcomeViewModelTests.swift
+++ b/RockxyTests/ViewModels/WelcomeViewModelTests.swift
@@ -156,4 +156,90 @@ struct WelcomeViewModelTests {
         #expect(viewModel.totalSteps == 4)
         #expect(viewModel.canGetStarted == false)
     }
+
+    // MARK: - Signing Mismatch Tests
+
+    @Test("completedSteps does not count signingMismatch as complete")
+    func completedStepsSigningMismatch() {
+        let viewModel = WelcomeViewModel()
+        viewModel.helperStatus = .signingMismatch
+
+        #expect(viewModel.completedSteps == 0)
+    }
+
+    @Test("canGetStarted is false when helper has signing mismatch")
+    func canGetStartedFalseSigningMismatch() {
+        let viewModel = WelcomeViewModel()
+        viewModel.certInstalled = true
+        viewModel.certTrusted = true
+        viewModel.helperStatus = .signingMismatch
+        viewModel.systemProxyEnabled = true
+
+        #expect(viewModel.canGetStarted == false)
+    }
+
+    @Test("subtype-only change through applyHelperState diverges action label")
+    func subtypeChangeThroughApplyPath() {
+        let viewModel = WelcomeViewModel()
+
+        viewModel.applyHelperState(
+            status: .signingMismatch,
+            signingIssue: .appSignatureInvalid(detail: "stale")
+        )
+        #expect(viewModel.helperStatus == .signingMismatch)
+        #expect(viewModel.helperSigningIssue == .appSignatureInvalid(detail: "stale"))
+        let label1 = HelperManager.helperActionLabel(
+            status: viewModel.helperStatus,
+            signingIssue: viewModel.helperSigningIssue
+        )
+        #expect(label1 == nil)
+
+        viewModel.applyHelperState(
+            status: .signingMismatch,
+            signingIssue: .identityMismatch(appSigner: "Dev", helperSigner: "Prod")
+        )
+        #expect(viewModel.helperStatus == .signingMismatch)
+        #expect(
+            viewModel.helperSigningIssue == .identityMismatch(
+                appSigner: "Dev",
+                helperSigner: "Prod"
+            )
+        )
+        let label2 = HelperManager.helperActionLabel(
+            status: viewModel.helperStatus,
+            signingIssue: viewModel.helperSigningIssue
+        )
+        #expect(label2 == String(localized: "Reinstall"))
+    }
+
+    // MARK: - Helper Action Label Alignment
+
+    @Test("unreachable label is Retry, not Install")
+    func unreachableLabelIsRetry() {
+        let label = HelperManager.helperActionLabel(
+            status: .unreachable,
+            signingIssue: nil
+        )
+        #expect(label == String(localized: "Retry"))
+    }
+
+    @Test("action labels cover all statuses consistently")
+    func actionLabelsAllStatuses() {
+        let cases: [(HelperManager.HelperStatus, HelperManager.SigningIssue?, String?)] = [
+            (.notInstalled, nil, String(localized: "Install")),
+            (.requiresApproval, nil, String(localized: "Open Settings")),
+            (.installedCompatible, nil, nil),
+            (.installedOutdated, nil, String(localized: "Update")),
+            (.installedIncompatible, nil, String(localized: "Update")),
+            (.unreachable, nil, String(localized: "Retry")),
+            (.signingMismatch, .appSignatureInvalid(detail: "x"), nil),
+            (.signingMismatch, .identityMismatch(appSigner: "a", helperSigner: "b"), String(localized: "Reinstall")),
+            (.signingMismatch, nil, nil),
+        ]
+
+        for (status, issue, expected) in cases {
+            let label = HelperManager.helperActionLabel(status: status, signingIssue: issue)
+            #expect(label == expected, "status=\(status) issue=\(String(describing: issue))")
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Adds app-side signing diagnostics at the XPC connection boundary to detect why the helper rejects connections, instead of entering a futile unregister/re-register loop
- Distinguishes two root causes with different user-facing guidance:
  - **Invalid app signature** (stale build) — surfaces clean-build guidance, no reinstall button
  - **Signing identity mismatch** (different certificate chain) — surfaces reinstall-helper guidance
- Adds BTM desync recovery via force-reset registration when System Settings approval toggle has no effect
- Helper-side caller validation is unchanged — no security weakening

## Problem

When the installed helper was signed by a different build (e.g., release DMG vs Xcode development build), the helper correctly rejected XPC connections due to certificate chain mismatch. But the app had no way to diagnose this — it treated every XPC timeout identically and looped through:

`timeout → unregister/re-register → timeout → installedIncompatible → "Update" button → same loop`

A separate issue: macOS BTM (Background Task Management) could get stuck in a `requiresApproval` state where toggling the Login Items switch had no effect, leaving users with no recovery path.

## Approach

**Signing diagnostics** (`SigningDiagnostics.swift`):
- Pure classification utility with `Environment` protocol for testability
- `LiveEnvironment` uses Security framework (`SecCodeCopySelf`, `SecStaticCodeCreateWithPath`, `SecCertificateCopyData`) to compare app and installed helper certificate chains
- Cached in `SigningPreflightCache` at the `HelperConnection` boundary — runs once, invalidated on helper lifecycle transitions

**Recovery logic** (`HelperManager.checkEnabledHelper`):
- Catches typed `HelperConnectionError.appSignatureInvalid` / `.signingIdentityMismatch` from the preflight
- Surfaces the real cause immediately without attempting re-registration
- Only retries unregister/re-register for genuine XPC failures

**State propagation**:
- New `HelperStatus.signingMismatch` case with `SigningIssue` subtype
- Propagated through `ReadinessCoordinator` → `WelcomeViewModel` → views
- Subtype-only changes (e.g., `.appSignatureInvalid` → `.identityMismatch`) trigger notification even when status stays `.signingMismatch`

**BTM recovery** (`forceResetRegistration()`):
- Fully unregisters, clears state, waits for BTM to settle, then re-registers fresh
- Exposed as "Reset Registration" button in Advanced Proxy Settings

## Files changed (15)

| Area | Files |
|---|---|
| New | `SigningDiagnostics.swift`, `SigningDiagnosticsTests.swift` |
| Core | `HelperManager.swift`, `HelperConnection.swift`, `ReadinessCoordinator.swift`, `CertificateManager.swift` |
| Helper | `ConnectionValidator.swift` (logging only) |
| UI | `WelcomeView.swift`, `WelcomeViewModel.swift`, `AdvancedProxySettingsView.swift`, `AdvancedSettingsTab.swift` |
| Tests | `HelperManagerTests.swift`, `HelperConnectionTests.swift`, `ReadinessCoordinatorTests.swift`, `WelcomeViewModelTests.swift` |

## Test plan

- [x] 11 `SigningDiagnosticsTests` — pure classification + stale-cache regression
- [x] 15 `HelperManagerTests` — probe classification, recovery decision, change detection, action labels, warning text, approval detection, uninstall reset
- [x] 7 `HelperConnectionTests` — error descriptions including new signing cases
- [x] 1 `ReadinessCoordinatorTests` — real notification-path propagation for subtype-only signing issue changes
- [x] 5 `WelcomeViewModelTests` — signing mismatch exclusion, apply-path regression, action label alignment
- [x] Build: `xcodebuild -configuration Debug build` passes
- [x] Lint: `swiftlint lint --strict` — 0 violations
- [ ] Manual: run from Xcode with release-installed helper → immediate signing mismatch guidance
- [ ] Manual: stale DerivedData → invalid app signature guidance, no reinstall button
- [ ] Manual: BTM stuck at requiresApproval → "Reset Registration" button unblocks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added code-signing validation for the helper tool to detect mismatches between app and helper signatures
  * New helper status with recovery options including registration reset and reinstallation
  * Enhanced diagnostics with detailed error messages for signing issues

* **Bug Fixes**
  * Improved error reporting for code-signing failures with human-readable descriptions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->