### PR TITLE
Improve domain grouping and helper recovery

### DIFF
--- a/Rockxy.xcodeproj/project.pbxproj
+++ b/Rockxy.xcodeproj/project.pbxproj
@@ -439,6 +439,7 @@
 				DCA9D0092F700000005B1552 /* Embed Helper Tool */,
 				DCA9D0102F700001005B1552 /* Copy LaunchDaemon Plist */,
 				DCA9D0212F700100005B1552 /* Generate Helper LaunchDaemon Plist */,
+				9E4B01973C7D49B7A8A83E54 /* Prepare MCP Tool Embed */,
 				861B86028DECFA198C672853 /* Embed MCP Tool */,
 			);
 			buildRules = (
@@ -615,6 +616,21 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		9E4B01973C7D49B7A8A83E54 /* Prepare MCP Tool Embed */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Prepare MCP Tool Embed";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -e\n\ncase \"$TARGET_BUILD_DIR\" in\n    */DerivedData/*/Build/Products/*) ;;\n    *) exit 0 ;;\nesac\n\nDEST=\"${TARGET_BUILD_DIR}/${EXECUTABLE_FOLDER_PATH}/rockxy-mcp\"\n\n# Xcode can fail to replace the embedded CLI if an MCP client still has the\n# previous DerivedData copy running. Stop only the bridge from this build bundle.\nif [ -n \"$DEST\" ]; then\n    /usr/bin/pkill -f \"$DEST\" 2>/dev/null || true\nfi\n\nif [ -e \"$DEST\" ]; then\n    /bin/chmod u+w \"$DEST\" 2>/dev/null || true\n    /bin/rm -f \"$DEST\"\nfi\n";
+		};
 		DCA9D0212F700100005B1552 /* Generate Helper LaunchDaemon Plist */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;

--- a/Rockxy/ContentView.swift
+++ b/Rockxy/ContentView.swift
@@ -46,12 +46,7 @@ struct ContentView: View {
         .toolbar {
             ProxyToolbarContent(coordinator: coordinator)
         }
-        .onReceive(NotificationCenter.default.publisher(for: .breakpointHit)) { _ in
-            openWindow(id: "breakpoints")
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .openDiffWindow)) { _ in
-            openWindow(id: "diff")
-        }
+        .modifier(ContentWindowNotificationHandlers(coordinator: coordinator, openWindow: openWindow))
         .onAppear {
             guard !ProcessInfo.processInfo.isTestHost else {
                 return
@@ -76,32 +71,6 @@ struct ContentView: View {
             coordinator.setupRulesObserver()
             coordinator.setupSSLProxyingObserver()
             coordinator.loadInitialRules()
-        }
-        .onReceive(NotificationCenter.default.publisher(
-            for: RockxyIdentity.current.notificationName("openCustomColumnsWindow")
-        )) { _ in
-            openWindow(id: "customColumns")
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .openComposeWindow)) { _ in
-            openWindow(id: "compose")
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .openBlockListWindow)) { _ in
-            openWindow(id: "blockList")
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .openAllowListWindow)) { _ in
-            openWindow(id: "allowList")
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .openMapLocalWindow)) { _ in
-            openWindow(id: "mapLocal")
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .openMapRemoteWindow)) { _ in
-            openWindow(id: "mapRemote")
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .openNetworkConditionsWindow)) { _ in
-            openWindow(id: "networkConditions")
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .openBreakpointRulesWindow)) { _ in
-            openWindow(id: "breakpointRules")
         }
         .modifier(ScriptingWindowOpeners(openWindow: openWindow))
         .alert(
@@ -180,6 +149,52 @@ struct ContentView: View {
         case nil:
             break
         }
+    }
+}
+
+// MARK: - Content Window Notification Handlers
+
+private struct ContentWindowNotificationHandlers: ViewModifier {
+    let coordinator: MainContentCoordinator
+    let openWindow: OpenWindowAction
+
+    func body(content: Content) -> some View {
+        content
+            .onReceive(NotificationCenter.default.publisher(for: .breakpointHit)) { _ in
+                openWindow(id: "breakpoints")
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .openDiffWindow)) { _ in
+                openWindow(id: "diff")
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .stopProxyRequested)) { _ in
+                coordinator.stopProxy()
+            }
+            .onReceive(NotificationCenter.default.publisher(
+                for: RockxyIdentity.current.notificationName("openCustomColumnsWindow")
+            )) { _ in
+                openWindow(id: "customColumns")
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .openComposeWindow)) { _ in
+                openWindow(id: "compose")
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .openBlockListWindow)) { _ in
+                openWindow(id: "blockList")
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .openAllowListWindow)) { _ in
+                openWindow(id: "allowList")
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .openMapLocalWindow)) { _ in
+                openWindow(id: "mapLocal")
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .openMapRemoteWindow)) { _ in
+                openWindow(id: "mapRemote")
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .openNetworkConditionsWindow)) { _ in
+                openWindow(id: "networkConditions")
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .openBreakpointRulesWindow)) { _ in
+                openWindow(id: "breakpointRules")
+            }
     }
 }
 

--- a/Rockxy/Core/ProxyEngine/HelperManager+ForceRemove.swift
+++ b/Rockxy/Core/ProxyEngine/HelperManager+ForceRemove.swift
@@ -1,0 +1,241 @@
+import Foundation
+
+extension HelperManager {
+    enum ForceRemoveError: LocalizedError, Equatable {
+        case commandFailed(exitCode: Int32, output: String)
+        case commandTerminated(signal: Int32, output: String)
+
+        var errorDescription: String? {
+            switch self {
+            case let .commandFailed(exitCode, output):
+                if output.localizedCaseInsensitiveContains("User canceled") {
+                    return String(localized: "The administrator authorization prompt was cancelled.")
+                }
+                if output.isEmpty {
+                    return String(localized: "Force reset failed with exit code \(exitCode).")
+                }
+                return String(localized: "Force reset failed with exit code \(exitCode): \(output)")
+            case let .commandTerminated(signal, output):
+                if output.isEmpty {
+                    return String(localized: "Force reset was interrupted by signal \(signal).")
+                }
+                return String(localized: "Force reset was interrupted by signal \(signal): \(output)")
+            }
+        }
+    }
+
+    struct ForceRemoveResult: Equatable {
+        let resetBackgroundItems: Bool
+        let commandOutput: String
+
+        var localizedSummary: String {
+            if resetBackgroundItems {
+                return String(
+                    localized: """
+                    Rockxy removed stale helper files and asked macOS to reset Login and Background Items data.
+                    """
+                )
+            }
+
+            return String(localized: "Rockxy removed stale helper files and launchd registration state.")
+        }
+    }
+
+    nonisolated static func forceRemoveShellScript(
+        identity: RockxyIdentity,
+        resetBackgroundItems: Bool
+    )
+        -> String
+    {
+        let label = shellQuote(identity.helperMachServiceName)
+        let helperPath = shellQuote("/Library/PrivilegedHelperTools/\(identity.helperMachServiceName)")
+        let launchDaemonPath = shellQuote("/Library/LaunchDaemons/\(identity.helperPlistName)")
+        let helperProcessPattern = shellQuote("[R]ockxyHelperTool")
+        var commands = [
+            consoleUserShellPrelude(),
+            directWatchdogCleanupCommand(identity: identity),
+            "/bin/launchctl bootout system/\(label) 2>/dev/null || true",
+            "/usr/bin/pkill -f \(helperProcessPattern) 2>/dev/null || true",
+            "/bin/rm -f \(helperPath)",
+            "/bin/rm -f \(launchDaemonPath)",
+        ]
+
+        if resetBackgroundItems {
+            commands.append("/usr/bin/sfltool resetbtm 2>/dev/null || true")
+        }
+
+        commands.append(contentsOf: [
+            loadedJobVerificationCommand(label: label),
+            "if [ -e \(helperPath) ]; then echo 'Rockxy helper binary still exists.' >&2; exit 21; fi",
+            "if [ -e \(launchDaemonPath) ]; then echo 'Rockxy launch daemon plist still exists.' >&2; exit 22; fi",
+            "echo 'Rockxy helper registration files were removed.'",
+        ])
+
+        return commands.joined(separator: "; ")
+    }
+
+    nonisolated static func shouldUseLegacyInstallFallbackForCurrentBundle(
+        bundleURL: URL = Bundle.main.bundleURL
+    ) -> Bool {
+        let path = bundleURL.path
+        return path.contains("/DerivedData/") && path.contains("/Build/Products/")
+    }
+
+    nonisolated static func legacyInstalledHelperPath(identity: RockxyIdentity) -> String {
+        "/Library/PrivilegedHelperTools/\(identity.helperMachServiceName)"
+    }
+
+    nonisolated static func legacyLaunchDaemonPlistPath(identity: RockxyIdentity) -> String {
+        "/Library/LaunchDaemons/\(identity.helperPlistName)"
+    }
+
+    nonisolated static func legacyInstallShellScript(
+        identity: RockxyIdentity,
+        bundledHelperPath: String
+    )
+        -> String
+    {
+        let label = shellQuote(identity.helperMachServiceName)
+        let sourceHelperPath = shellQuote(bundledHelperPath)
+        let installedHelperPath = legacyInstalledHelperPath(identity: identity)
+        let launchDaemonPlistPath = legacyLaunchDaemonPlistPath(identity: identity)
+        let helperPath = shellQuote(installedHelperPath)
+        let launchDaemonPath = shellQuote(launchDaemonPlistPath)
+        let plist = legacyLaunchDaemonPlist(identity: identity, helperPath: installedHelperPath)
+        let plistBase64 = shellQuote(Data(plist.utf8).base64EncodedString())
+
+        return [
+            consoleUserShellPrelude(),
+            directWatchdogCleanupCommand(identity: identity),
+            "/bin/launchctl bootout system/\(label) 2>/dev/null || true",
+            "/usr/bin/pkill -f '[R]ockxyHelperTool' 2>/dev/null || true",
+            "/usr/bin/install -o root -g wheel -m 755 \(sourceHelperPath) \(helperPath)",
+            "/bin/echo \(plistBase64) | /usr/bin/base64 -D > \(launchDaemonPath)",
+            "/usr/sbin/chown root:wheel \(launchDaemonPath)",
+            "/bin/chmod 644 \(launchDaemonPath)",
+            "/bin/launchctl bootstrap system \(launchDaemonPath)",
+            "/bin/launchctl enable system/\(label) 2>/dev/null || true",
+            "/bin/launchctl kickstart -k system/\(label) 2>/dev/null || true",
+            "if ! /bin/launchctl print system/\(label) >/dev/null 2>&1; then echo 'Rockxy helper launchd job was not registered.' >&2; exit 30; fi",
+            "echo 'Rockxy helper was installed into the privileged helper location.'",
+        ].joined(separator: "; ")
+    }
+
+    nonisolated static func privilegedAppleScript(for shellScript: String) -> String {
+        let escapedScript = shellScript
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        return "do shell script \"\(escapedScript)\" with administrator privileges"
+    }
+
+    nonisolated static func runPrivilegedShellScript(_ shellScript: String) async throws -> String {
+        let appleScript = privilegedAppleScript(for: shellScript)
+
+        return try await Task.detached(priority: .userInitiated) {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+            process.arguments = ["-e", appleScript]
+
+            let pipe = Pipe()
+            process.standardOutput = pipe
+            process.standardError = pipe
+
+            try process.run()
+            process.waitUntilExit()
+
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: data, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            guard process.terminationStatus == 0 else {
+                if process.terminationReason == .uncaughtSignal {
+                    throw ForceRemoveError.commandTerminated(
+                        signal: process.terminationStatus,
+                        output: output
+                    )
+                }
+
+                throw ForceRemoveError.commandFailed(
+                    exitCode: process.terminationStatus,
+                    output: output
+                )
+            }
+
+            return output
+        }.value
+    }
+
+    nonisolated private static func loadedJobVerificationCommand(label: String) -> String {
+        "if /bin/launchctl print system/\(label) >/dev/null 2>&1; then " +
+            "echo 'Rockxy helper launchd job is still loaded.' >&2; exit 20; fi"
+    }
+
+    nonisolated private static func directWatchdogCleanupCommand(identity: RockxyIdentity) -> String {
+        let label = shellQuote("\(identity.appBundleIdentifier).direct-proxy-watchdog")
+        let backupPath = "\"$CONSOLE_HOME/Library/Application Support/\(shellDoubleQuotedPathComponent(identity.appSupportDirectoryName))/proxy-backup-direct.plist\""
+        return """
+        if [ -n "$CONSOLE_UID" ]; then /bin/launchctl bootout gui/$CONSOLE_UID/\(label) 2>/dev/null || true; fi; \
+        /bin/rm -f \(backupPath) 2>/dev/null || true
+        """
+    }
+
+    nonisolated private static func consoleUserShellPrelude() -> String {
+        """
+        CONSOLE_USER=$(/usr/bin/stat -f %Su /dev/console 2>/dev/null || true); \
+        if [ -n "$CONSOLE_USER" ] && [ "$CONSOLE_USER" != "root" ]; then \
+        CONSOLE_UID=$(/usr/bin/id -u "$CONSOLE_USER" 2>/dev/null || true); \
+        CONSOLE_HOME=$(/usr/bin/dscl . -read "/Users/$CONSOLE_USER" NFSHomeDirectory 2>/dev/null | /usr/bin/awk '{print $2}' || true); \
+        else CONSOLE_UID=""; CONSOLE_HOME=""; fi
+        """
+    }
+
+    nonisolated private static func legacyLaunchDaemonPlist(identity: RockxyIdentity, helperPath: String) -> String {
+        let associatedBundleIdentifiers = identity.allowedCallerIdentifiers
+            .map { "\t\t<string>\(xmlEscaped($0))</string>" }
+            .joined(separator: "\n")
+        return """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+        \t<key>Label</key>
+        \t<string>\(xmlEscaped(identity.helperMachServiceName))</string>
+        \t<key>ProgramArguments</key>
+        \t<array>
+        \t\t<string>\(xmlEscaped(helperPath))</string>
+        \t</array>
+        \t<key>MachServices</key>
+        \t<dict>
+        \t\t<key>\(xmlEscaped(identity.helperMachServiceName))</key>
+        \t\t<true/>
+        \t</dict>
+        \t<key>AssociatedBundleIdentifiers</key>
+        \t<array>
+        \(associatedBundleIdentifiers)
+        \t</array>
+        </dict>
+        </plist>
+        """
+    }
+
+    nonisolated private static func xmlEscaped(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&apos;")
+    }
+
+    nonisolated private static func shellDoubleQuotedPathComponent(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "$", with: "\\$")
+            .replacingOccurrences(of: "`", with: "\\`")
+    }
+
+    nonisolated private static func shellQuote(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
+    }
+}

--- a/Rockxy/Core/ProxyEngine/HelperManager.swift
+++ b/Rockxy/Core/ProxyEngine/HelperManager.swift
@@ -43,7 +43,7 @@ final class HelperManager {
     enum RecoveryAction: Equatable {
         case surfaceAppSignatureInvalid(detail: String)
         case surfaceSigningMismatch(appSigner: String, helperSigner: String)
-        case attemptReRegistration
+        case surfaceUnreachable
     }
 
     enum InstallDisposition: Equatable {
@@ -382,7 +382,7 @@ final class HelperManager {
         case let .signingIdentityMismatch(app, helper):
             .surfaceSigningMismatch(appSigner: app, helperSigner: helper)
         case .xpcFailure:
-            .attemptReRegistration
+            .surfaceUnreachable
         }
     }
 
@@ -470,7 +470,7 @@ final class HelperManager {
                 previousSigningIssue: previousSigningIssue
             )
         }
-        try performInstall()
+        try await performInstall()
         if status != .requiresApproval {
             await performCheckStatus()
         }
@@ -543,7 +543,7 @@ final class HelperManager {
         do {
             try await performUninstall()
             try? await Task.sleep(nanoseconds: 500_000_000)
-            try performInstall()
+            try await performInstall()
             if status != .requiresApproval {
                 await performCheckStatus()
             }
@@ -595,7 +595,7 @@ final class HelperManager {
         }
         do {
             try await performUninstall()
-            try performInstall()
+            try await performInstall()
             if status != .requiresApproval {
                 await performCheckStatus()
             }
@@ -647,7 +647,7 @@ final class HelperManager {
         try? await Task.sleep(nanoseconds: 3_000_000_000)
 
         do {
-            try performInstall()
+            try await performInstall()
             if status != .requiresApproval {
                 await performCheckStatus()
             }
@@ -655,6 +655,65 @@ final class HelperManager {
             lastErrorMessage = error.localizedDescription
             throw error
         }
+    }
+
+    /// Hard-remove the helper from launchd and privileged helper locations.
+    ///
+    /// This is intentionally separate from `forceResetRegistration()`. The registration
+    /// reset path is the normal SMAppService recovery path. Hard remove is a last-resort
+    /// recovery for BTM/launchd drift where XPC uninstall or SMAppService unregister
+    /// cannot get the app back to an observable state.
+    @discardableResult
+    func forceRemoveHelper(resetBackgroundItems: Bool) async throws -> ForceRemoveResult {
+        HelperConnection.shared.invalidateSigningCache()
+        let previousStatus = status
+        let previousReachable = isReachable
+        let previousInfo = installedInfo
+        let previousSigningIssue = signingIssue
+        lastErrorMessage = nil
+        isBusy = true
+        defer {
+            isBusy = false
+            postStatusChangeIfNeeded(
+                previousStatus: previousStatus,
+                previousReachable: previousReachable,
+                previousInfo: previousInfo,
+                previousSigningIssue: previousSigningIssue
+            )
+        }
+
+        Self.logger.info("Hard force-removing helper. resetBackgroundItems=\(resetBackgroundItems)")
+
+        do {
+            try await HelperConnection.shared.uninstallHelper()
+        } catch {
+            Self.logger.warning("Force remove could not notify helper before removal: \(error.localizedDescription)")
+        }
+
+        do {
+            try await SMAppService.daemon(plistName: Self.plistName).unregister()
+        } catch {
+            Self.logger.warning("Force remove SMAppService unregister failed: \(error.localizedDescription)")
+        }
+
+        let shellScript = Self.forceRemoveShellScript(
+            identity: RockxyIdentity.current,
+            resetBackgroundItems: resetBackgroundItems
+        )
+        let commandOutput = try await Self.runPrivilegedShellScript(shellScript)
+
+        status = .notInstalled
+        installedInfo = nil
+        isReachable = false
+        registrationStatus = "Not Registered"
+        HelperConnection.shared.resetConnection()
+
+        await performCheckStatus()
+
+        return ForceRemoveResult(
+            resetBackgroundItems: resetBackgroundItems,
+            commandOutput: commandOutput
+        )
     }
 
     // MARK: - Test Support
@@ -873,7 +932,7 @@ final class HelperManager {
     }
 
     /// Core install logic without busy/error wrapper.
-    private func performInstall() throws {
+    private func performInstall() async throws {
         Self.logger.info("Installing helper tool")
         do {
             try Self.validateBundledHelperInstallResources()
@@ -890,6 +949,13 @@ final class HelperManager {
 
         switch Self.installDisposition(for: service.status) {
         case .requiresApproval:
+            if Self.shouldUseLegacyInstallFallbackForCurrentBundle() {
+                try await installLegacyHelperForXcode(
+                    service: service,
+                    reason: "SMAppService requires Login Items approval for an Xcode-run app bundle"
+                )
+                return
+            }
             Self.logger.info("Helper already registered and awaiting user approval")
             status = .requiresApproval
             registrationStatus = "Awaiting Approval"
@@ -899,7 +965,7 @@ final class HelperManager {
         case .alreadyEnabled:
             Self.logger.info("Helper tool is already registered")
             registrationStatus = "Enabled"
-            lastErrorMessage = nil
+            await verifyEnabledHelperOrRepair(service: service)
             return
         case .register:
             break
@@ -932,12 +998,83 @@ final class HelperManager {
             Self.logger.info("Helper tool installed and enabled")
             registrationStatus = "Enabled"
             lastErrorMessage = nil
-            status = .installedCompatible
+            await verifyEnabledHelperOrRepair(service: service)
         } else {
             Self.logger.warning(
                 "Unexpected SMAppService status after register: \(String(describing: currentStatus))"
             )
             status = .notInstalled
+        }
+    }
+
+    /// `SMAppService` can report `.enabled` while launchd is holding a broken submitted job
+    /// after a hard reset or when running directly from Xcode's DerivedData. Install is an
+    /// explicit repair action, so it may mutate registration if the enabled service cannot
+    /// answer XPC.
+    private func verifyEnabledHelperOrRepair(service: SMAppService) async {
+        do {
+            let info = try await probeHelperInfo()
+            installedInfo = info
+            isReachable = true
+            lastErrorMessage = nil
+            status = evaluateCompatibility(info)
+        } catch {
+            Self.logger.warning("Enabled helper did not answer during install: \(error.localizedDescription)")
+            installedInfo = nil
+            isReachable = false
+
+            guard Self.shouldUseLegacyInstallFallbackForCurrentBundle() else {
+                setUnreachableState(reason: error.localizedDescription)
+                return
+            }
+
+            do {
+                try await installLegacyHelperForXcode(service: service, reason: error.localizedDescription)
+            } catch {
+                lastErrorMessage = error.localizedDescription
+                status = .unreachable
+            }
+        }
+    }
+
+    /// Xcode-run app bundles live in DerivedData. On some macOS versions, `SMAppService.daemon`
+    /// can register the embedded LaunchDaemon but launchd fails the system job before the Mach
+    /// service becomes usable. For that development-only case, install the same helper identity
+    /// into the traditional privileged helper location.
+    private func installLegacyHelperForXcode(service: SMAppService, reason: String) async throws {
+        Self.logger.warning("Repairing Xcode helper registration via legacy launchd install: \(reason)")
+
+        do {
+            try await service.unregister()
+        } catch {
+            Self.logger.warning("Legacy helper repair could not unregister SMAppService job: \(error.localizedDescription)")
+        }
+
+        HelperConnection.shared.resetConnection()
+        try? await Task.sleep(nanoseconds: 1_000_000_000)
+
+        let bundledHelperURL = Bundle.main.bundleURL
+            .appendingPathComponent(Self.bundledHelperBinaryRelativePath, isDirectory: false)
+        let shellScript = Self.legacyInstallShellScript(
+            identity: RockxyIdentity.current,
+            bundledHelperPath: bundledHelperURL.path
+        )
+        _ = try await Self.runPrivilegedShellScript(shellScript)
+
+        registrationStatus = "Enabled"
+        HelperConnection.shared.invalidateSigningCache()
+        HelperConnection.shared.resetConnection()
+        try? await Task.sleep(nanoseconds: 1_000_000_000)
+
+        do {
+            let info = try await probeHelperInfo()
+            installedInfo = info
+            isReachable = true
+            lastErrorMessage = nil
+            status = evaluateCompatibility(info)
+        } catch {
+            setUnreachableState(reason: error.localizedDescription)
+            throw error
         }
     }
 
@@ -988,9 +1125,15 @@ final class HelperManager {
         case .enabled:
             await checkEnabledHelper(service: service)
         case .requiresApproval:
+            if await checkLegacyLaunchdHelperIfAvailable() {
+                break
+            }
             status = .requiresApproval
         case .notRegistered,
              .notFound:
+            if await checkLegacyLaunchdHelperIfAvailable() {
+                break
+            }
             status = .notInstalled
             installedInfo = nil
             isReachable = false
@@ -1004,10 +1147,24 @@ final class HelperManager {
         Self.logger.info("Helper status: \(String(describing: self.status))")
     }
 
-    /// Handle the case where SMAppService reports the helper as enabled.
-    /// Checks XPC reachability, then evaluates protocol-aware compatibility.
-    /// Signing-related failures are surfaced immediately without re-registration attempts.
-    private func checkEnabledHelper(service: SMAppService) async {
+    /// Xcode fallback installs the same helper identity through a traditional LaunchDaemon.
+    /// `SMAppService` does not own that job, so status checks need an artifact-and-XPC path.
+    private func checkLegacyLaunchdHelperIfAvailable() async -> Bool {
+        guard Self.shouldUseLegacyInstallFallbackForCurrentBundle() else {
+            return false
+        }
+
+        let identity = RockxyIdentity.current
+        let helperPath = Self.legacyInstalledHelperPath(identity: identity)
+        let plistPath = Self.legacyLaunchDaemonPlistPath(identity: identity)
+        let hasLegacyArtifacts = FileManager.default.fileExists(atPath: helperPath)
+            || FileManager.default.fileExists(atPath: plistPath)
+        guard hasLegacyArtifacts else {
+            return false
+        }
+
+        registrationStatus = "Enabled"
+
         do {
             let info = try await probeHelperInfo()
             installedInfo = info
@@ -1021,85 +1178,61 @@ final class HelperManager {
             switch action {
             case let .surfaceAppSignatureInvalid(detail):
                 setSigningMismatchState(.appSignatureInvalid(detail: detail))
-                return
 
             case let .surfaceSigningMismatch(app, helper):
                 setSigningMismatchState(.identityMismatch(appSigner: app, helperSigner: helper))
-                return
 
-            case .attemptReRegistration:
-                Self.logger.info(
-                    "Helper registered but not responding (\(error.localizedDescription)) — attempting re-registration"
-                )
-                do {
-                    guard try await reRegister(service: service) else {
-                        return
-                    }
-                    do {
-                        let info = try await probeHelperInfo()
-                        installedInfo = info
-                        isReachable = true
-                        lastErrorMessage = nil
-                        status = evaluateCompatibility(info)
-                    } catch let retryError as HelperConnectionError {
-                        let retryProbe = Self.classifyProbeError(retryError)
-                        let retryAction = Self.decideRecovery(probe: retryProbe)
-                        switch retryAction {
-                        case let .surfaceAppSignatureInvalid(detail):
-                            setSigningMismatchState(.appSignatureInvalid(detail: detail))
-                        case let .surfaceSigningMismatch(app, helper):
-                            setSigningMismatchState(.identityMismatch(appSigner: app, helperSigner: helper))
-                        case .attemptReRegistration:
-                            Self.logger.warning(
-                                "Helper still not responding after re-registration: \(retryError.localizedDescription)"
-                            )
-                            installedInfo = nil
-                            isReachable = false
-                            lastErrorMessage = String(
-                                localized: "Helper is installed but incompatible or unreachable. Try reinstalling the helper tool."
-                            )
-                            status = .installedIncompatible
-                        }
-                    } catch {
-                        Self.logger.warning(
-                            "Helper still not responding after re-registration: \(error.localizedDescription)"
-                        )
-                        installedInfo = nil
-                        isReachable = false
-                        lastErrorMessage = String(
-                            localized: "Helper is installed but incompatible or unreachable. Try reinstalling the helper tool."
-                        )
-                        status = .installedIncompatible
-                    }
-                } catch {
-                    Self.logger.warning("Re-registration failed: \(error.localizedDescription)")
-                    installedInfo = nil
-                    isReachable = false
-                    lastErrorMessage = error.localizedDescription
-                    status = .unreachable
-                }
+            case .surfaceUnreachable:
+                setUnreachableState(reason: error.localizedDescription)
             }
         } catch {
-            Self.logger.info(
-                "Helper registered but not responding (\(error.localizedDescription)) — attempting re-registration"
-            )
-            do {
-                guard try await reRegister(service: service) else {
-                    return
-                }
-                let info = try await probeHelperInfo()
-                installedInfo = info
-                isReachable = true
-                lastErrorMessage = nil
-                status = evaluateCompatibility(info)
-            } catch {
-                Self.logger.warning("Re-registration failed: \(error.localizedDescription)")
-                installedInfo = nil
-                isReachable = false
-                lastErrorMessage = error.localizedDescription
-                status = .unreachable
-            }
+            setUnreachableState(reason: error.localizedDescription)
         }
+
+        return true
+    }
+
+    /// Handle the case where SMAppService reports the helper as enabled.
+    /// Checks XPC reachability, then evaluates protocol-aware compatibility.
+    /// Signing-related failures are surfaced immediately without re-registration attempts.
+    private func checkEnabledHelper(service _: SMAppService) async {
+        do {
+            let info = try await probeHelperInfo()
+            installedInfo = info
+            isReachable = true
+            lastErrorMessage = nil
+            status = evaluateCompatibility(info)
+        } catch let error as HelperConnectionError {
+            let probe = Self.classifyProbeError(error)
+            let action = Self.decideRecovery(probe: probe)
+
+            switch action {
+            case let .surfaceAppSignatureInvalid(detail):
+                setSigningMismatchState(.appSignatureInvalid(detail: detail))
+
+            case let .surfaceSigningMismatch(app, helper):
+                setSigningMismatchState(.identityMismatch(appSigner: app, helperSigner: helper))
+
+            case .surfaceUnreachable:
+                setUnreachableState(reason: error.localizedDescription)
+            }
+        } catch {
+            setUnreachableState(reason: error.localizedDescription)
+        }
+    }
+
+    /// Surface XPC failure without mutating macOS Background Items registration.
+    private func setUnreachableState(reason: String) {
+        Self.logger.warning("Helper registered but not reachable: \(reason)")
+        installedInfo = nil
+        isReachable = false
+        lastErrorMessage = String(
+            localized: """
+            Helper is registered in macOS but Rockxy could not reach it. \
+            Check again, reinstall the helper from the current build, or use Force Reset if macOS Login Items is stuck.
+            """
+        )
+        status = .unreachable
     }
 
     /// Centralized state setter for signing mismatch conditions.
@@ -1126,43 +1259,6 @@ final class HelperManager {
             )
         }
         status = .signingMismatch
-    }
-
-    /// Attempt to re-register the helper via SMAppService, handling the case where
-    /// the new registration requires Login Items approval. Returns `true` if the
-    /// service is now enabled and probing should proceed, or `false` if approval is
-    /// required and the caller should stop the retry path.
-    private func reRegister(service: SMAppService) async throws -> Bool {
-        try await service.unregister()
-        try? await Task.sleep(nanoseconds: 2_000_000_000)
-
-        do {
-            try service.register()
-        } catch {
-            if Self.requiresApproval(error: error, serviceStatus: service.status) {
-                Self.logger.info("Re-registration requires user approval in System Settings")
-                status = .requiresApproval
-                registrationStatus = "Awaiting Approval"
-                lastErrorMessage = Self.approvalMessage(error: error, serviceStatus: service.status)
-                SMAppService.openSystemSettingsLoginItems()
-                return false
-            }
-            throw error
-        }
-
-        let currentStatus = service.status
-        if currentStatus == .requiresApproval {
-            Self.logger.info("Re-registered helper requires user approval in System Settings")
-            status = .requiresApproval
-            registrationStatus = "Awaiting Approval"
-            lastErrorMessage = Self.helperApprovalMessage
-            SMAppService.openSystemSettingsLoginItems()
-            return false
-        }
-
-        try? await Task.sleep(nanoseconds: 2_000_000_000)
-        HelperConnection.shared.resetConnection()
-        return true
     }
 
     /// Evaluate helper compatibility based on protocol version and build number.

--- a/Rockxy/Core/Services/Infrastructure/AppNotifications.swift
+++ b/Rockxy/Core/Services/Infrastructure/AppNotifications.swift
@@ -8,6 +8,7 @@ extension Notification.Name {
 
     static let proxyDidStart = identity.notificationName("proxyDidStart")
     static let proxyDidStop = identity.notificationName("proxyDidStop")
+    static let stopProxyRequested = identity.notificationName("stopProxyRequested")
     static let systemProxyDidChange = identity.notificationName("systemProxyDidChange")
     static let certificateStatusChanged = identity.notificationName("certificateStatusChanged")
     static let helperStatusChanged = identity.notificationName("helperStatusChanged")

--- a/Rockxy/Core/Services/TrafficDomainSnapshot.swift
+++ b/Rockxy/Core/Services/TrafficDomainSnapshot.swift
@@ -31,7 +31,7 @@ final class TrafficDomainSnapshot {
             $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
         }
         var seen = Set<String>()
-        domains = domainTree.map(\.domain)
+        domains = domainTree.flatMap(Self.flattenDomains)
             .filter { seen.insert($0).inserted }
             .sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
     }
@@ -39,5 +39,10 @@ final class TrafficDomainSnapshot {
     func reset() {
         appEntries = []
         domains = []
+    }
+
+    private static func flattenDomains(from node: DomainNode) -> [String] {
+        let ownValue = node.kind == .path ? [] : [node.selectionDomain]
+        return ownValue + node.children.flatMap(flattenDomains)
     }
 }

--- a/Rockxy/Models/Rules/ModifyHeaderRuleBuilder.swift
+++ b/Rockxy/Models/Rules/ModifyHeaderRuleBuilder.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+enum ModifyHeaderRuleBuilder {
+    static func build(
+        existingRule: ProxyRule? = nil,
+        ruleName: String,
+        rawPattern: String,
+        httpMethod: HTTPMethodFilter,
+        matchType: RuleMatchType,
+        includeSubpaths: Bool,
+        operations: [HeaderOperation]
+    ) -> ProxyRule {
+        let trimmedPattern = rawPattern.trimmingCharacters(in: .whitespacesAndNewlines)
+        let pattern = RulePatternBuilder.regexSource(
+            rawPattern: trimmedPattern,
+            matchType: matchType,
+            includeSubpaths: matchType == .wildcard ? includeSubpaths : false
+        )
+        let displayName = ruleName.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        return ProxyRule(
+            id: existingRule?.id ?? UUID(),
+            name: displayName.isEmpty ? trimmedPattern : displayName,
+            isEnabled: existingRule?.isEnabled ?? true,
+            matchCondition: RuleMatchCondition(
+                urlPattern: pattern,
+                method: httpMethod.methodValue
+            ),
+            action: .modifyHeader(operations: operations),
+            priority: existingRule?.priority ?? 0
+        )
+    }
+}

--- a/Rockxy/Models/Rules/RulePatternBuilder.swift
+++ b/Rockxy/Models/Rules/RulePatternBuilder.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+enum RulePatternBuilder {
+    static func regexSource(
+        rawPattern: String,
+        matchType: RuleMatchType,
+        includeSubpaths: Bool
+    ) -> String {
+        switch matchType {
+        case .wildcard:
+            var pattern = NSRegularExpression.escapedPattern(for: rawPattern)
+                .replacingOccurrences(of: "\\*", with: ".*")
+                .replacingOccurrences(of: "\\?", with: ".")
+            if includeSubpaths {
+                if !pattern.hasSuffix(".*") {
+                    pattern += ".*"
+                }
+            } else {
+                pattern += "($|[?#])"
+            }
+            return pattern
+        case .regex:
+            return rawPattern
+        }
+    }
+}

--- a/Rockxy/Models/UI/DomainGrouping.swift
+++ b/Rockxy/Models/UI/DomainGrouping.swift
@@ -1,0 +1,312 @@
+import Foundation
+
+// Builds the sidebar domain hierarchy from captured traffic.
+
+// MARK: - DomainNode
+
+/// Represents a group in the sidebar domain source list.
+/// Domain and host nodes aggregate related hosts; path nodes aggregate request paths
+/// without hiding the underlying requests from the main traffic table.
+struct DomainNode: Identifiable, Hashable {
+    enum Kind: Hashable {
+        case domain
+        case host
+        case path
+    }
+
+    let id: String
+    let domain: String
+    var requestCount: Int
+    var children: [DomainNode]
+    var kind: Kind = .domain
+    var filterDomain: String?
+    var pathPrefix: String?
+    var errorCount: Int = 0
+    var methods: Set<String> = []
+    var firstSeenSequence = Int.max
+
+    var selectionDomain: String {
+        filterDomain ?? domain
+    }
+
+    static func == (lhs: DomainNode, rhs: DomainNode) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}
+
+// MARK: - DomainGroupingIndex
+
+struct DomainGroupingIndex {
+    // MARK: Internal
+
+    mutating func removeAll() {
+        nodesByID.removeAll(keepingCapacity: true)
+        childIDsByParentID.removeAll(keepingCapacity: true)
+        rootIDs.removeAll(keepingCapacity: true)
+    }
+
+    mutating func add(_ transaction: HTTPTransaction) {
+        let specs = DomainGrouping.nodeSpecs(for: transaction)
+        guard !specs.isEmpty else {
+            return
+        }
+
+        for spec in specs {
+            var node = nodesByID[spec.id] ?? DomainNode(
+                id: spec.id,
+                domain: spec.title,
+                requestCount: 0,
+                children: [],
+                kind: spec.kind,
+                filterDomain: spec.filterDomain,
+                pathPrefix: spec.pathPrefix,
+                firstSeenSequence: transaction.sequenceNumber
+            )
+            node.requestCount += 1
+            if DomainGrouping.isError(transaction) {
+                node.errorCount += 1
+            }
+            node.methods.insert(transaction.request.method)
+            node.firstSeenSequence = min(node.firstSeenSequence, transaction.sequenceNumber)
+            nodesByID[spec.id] = node
+
+            if let parentID = spec.parentID {
+                childIDsByParentID[parentID, default: []].insert(spec.id)
+            } else {
+                rootIDs.insert(spec.id)
+            }
+        }
+    }
+
+    func makeTree(alphabetical: Bool = false) -> [DomainNode] {
+        sorted(ids: rootIDs, alphabetical: alphabetical).map { makeNode(id: $0, alphabetical: alphabetical) }
+    }
+
+    // MARK: Private
+
+    private var nodesByID: [String: DomainNode] = [:]
+    private var childIDsByParentID: [String: Set<String>] = [:]
+    private var rootIDs: Set<String> = []
+
+    private func makeNode(id: String, alphabetical: Bool) -> DomainNode {
+        guard var node = nodesByID[id] else {
+            return DomainNode(id: id, domain: id, requestCount: 0, children: [])
+        }
+
+        let childIDs = childIDsByParentID[id] ?? []
+        node.children = sorted(ids: childIDs, alphabetical: alphabetical).map {
+            makeNode(id: $0, alphabetical: alphabetical)
+        }
+        return node
+    }
+
+    private func sorted(ids: Set<String>, alphabetical: Bool) -> [String] {
+        ids.sorted { lhsID, rhsID in
+            guard let lhs = nodesByID[lhsID], let rhs = nodesByID[rhsID] else {
+                return lhsID < rhsID
+            }
+            if alphabetical {
+                return lhs.domain.localizedCaseInsensitiveCompare(rhs.domain) == .orderedAscending
+            }
+            if lhs.firstSeenSequence != rhs.firstSeenSequence {
+                return lhs.firstSeenSequence < rhs.firstSeenSequence
+            }
+            return lhs.domain.localizedCaseInsensitiveCompare(rhs.domain) == .orderedAscending
+        }
+    }
+}
+
+// MARK: - DomainGrouping
+
+enum DomainGrouping {
+    struct NodeSpec {
+        let id: String
+        let parentID: String?
+        let title: String
+        let kind: DomainNode.Kind
+        let filterDomain: String
+        let pathPrefix: String?
+    }
+
+    static func nodeSpecs(for transaction: HTTPTransaction) -> [NodeSpec] {
+        let host = normalizedHost(transaction.request.host)
+        guard !host.isEmpty else {
+            return []
+        }
+
+        let rootDomain = registrableDomain(for: host)
+        let rootID = "domain:\(rootDomain)"
+        var specs = [
+            NodeSpec(
+                id: rootID,
+                parentID: nil,
+                title: rootDomain,
+                kind: .domain,
+                filterDomain: rootDomain,
+                pathPrefix: nil
+            ),
+        ]
+
+        let parentID: String
+        let pathFilterDomain: String
+        if host == rootDomain {
+            parentID = rootID
+            pathFilterDomain = rootDomain
+        } else {
+            let hostID = "host:\(host)"
+            specs.append(
+                NodeSpec(
+                    id: hostID,
+                    parentID: rootID,
+                    title: host,
+                    kind: .host,
+                    filterDomain: host,
+                    pathPrefix: nil
+                )
+            )
+            parentID = hostID
+            pathFilterDomain = host
+        }
+
+        specs.append(contentsOf: pathSpecs(
+            path: transaction.request.path,
+            parentID: parentID,
+            host: pathFilterDomain
+        ))
+        return specs
+    }
+
+    static func normalizedHost(_ host: String) -> String {
+        host.trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "."))
+            .lowercased()
+    }
+
+    static func host(_ host: String, matchesDomain domain: String) -> Bool {
+        let candidateHost = normalizedHost(host)
+        let candidateDomain = normalizedHost(domain)
+        return candidateHost == candidateDomain || candidateHost.hasSuffix(".\(candidateDomain)")
+    }
+
+    static func path(_ path: String, matchesPrefix prefix: String?) -> Bool {
+        guard let prefix, !prefix.isEmpty, prefix != "/" else {
+            return true
+        }
+        return path == prefix || path.hasPrefix(prefix.hasSuffix("/") ? prefix : "\(prefix)/")
+    }
+
+    static func isError(_ transaction: HTTPTransaction) -> Bool {
+        if transaction.state == .failed || transaction.isTLSFailure {
+            return true
+        }
+        guard let statusCode = transaction.response?.statusCode else {
+            return false
+        }
+        return statusCode >= 400
+    }
+
+    // MARK: Private
+
+    private static let maxPathDepth = 3
+
+    private static let multiPartPublicSuffixes: Set<String> = [
+        "ac.uk", "co.jp", "co.kr", "co.nz", "co.uk", "co.za", "com.au", "com.br",
+        "com.cn", "com.hk", "com.mx", "com.sg", "com.tr", "com.tw", "com.vn",
+        "edu.au", "gov.au", "gov.uk", "net.au", "net.cn", "net.nz", "ne.jp",
+        "org.au", "org.cn", "org.uk",
+    ]
+
+    private static func registrableDomain(for host: String) -> String {
+        if host == "localhost" || isIPAddress(host) {
+            return host
+        }
+
+        let parts = host.split(separator: ".").map(String.init)
+        guard parts.count > 2 else {
+            return host
+        }
+
+        let suffix = parts.suffix(2).joined(separator: ".")
+        let componentCount = multiPartPublicSuffixes.contains(suffix) ? 3 : 2
+        return parts.suffix(componentCount).joined(separator: ".")
+    }
+
+    private static func pathSpecs(path: String, parentID: String, host: String) -> [NodeSpec] {
+        let segments = path.split(separator: "/").map(String.init)
+        guard !segments.isEmpty else {
+            return []
+        }
+
+        var specs: [NodeSpec] = []
+        var currentParentID = parentID
+        var prefixSegments: [String] = []
+        for rawSegment in segments.prefix(maxPathDepth) {
+            prefixSegments.append(rawSegment)
+            let normalizedSegment = displaySegment(for: rawSegment, canCollapseDynamic: prefixSegments.count > 1)
+            let prefix = pathPrefix(for: prefixSegments, normalizedSegment: normalizedSegment)
+            let id = "path:\(host):\(prefix)"
+            specs.append(
+                NodeSpec(
+                    id: id,
+                    parentID: currentParentID,
+                    title: "/\(normalizedSegment)",
+                    kind: .path,
+                    filterDomain: host,
+                    pathPrefix: prefix
+                )
+            )
+            currentParentID = id
+        }
+        return specs
+    }
+
+    private static func pathPrefix(for segments: [String], normalizedSegment: String) -> String {
+        if normalizedSegment == "{id}", segments.count > 1 {
+            return "/" + segments.dropLast().joined(separator: "/") + "/"
+        }
+        return "/" + segments.joined(separator: "/")
+    }
+
+    private static func displaySegment(for segment: String, canCollapseDynamic: Bool) -> String {
+        if canCollapseDynamic, isDynamicPathSegment(segment) {
+            return "{id}"
+        }
+        if segment.count > 36 {
+            return String(segment.prefix(33)) + "..."
+        }
+        return segment
+    }
+
+    private static func isDynamicPathSegment(_ segment: String) -> Bool {
+        if segment.allSatisfy(\.isNumber) {
+            return true
+        }
+        if UUID(uuidString: segment) != nil {
+            return true
+        }
+        if segment.count >= 16, segment.allSatisfy(\.isHexDigit) {
+            return true
+        }
+        return false
+    }
+
+    private static func isIPAddress(_ host: String) -> Bool {
+        if host.contains(":") {
+            return true
+        }
+        let parts = host.split(separator: ".")
+        guard parts.count == 4 else {
+            return false
+        }
+        return parts.allSatisfy { part in
+            guard let value = Int(part), (0 ... 255).contains(value) else {
+                return false
+            }
+            return String(value) == part
+        }
+    }
+}

--- a/Rockxy/Models/UI/FilterCriteria.swift
+++ b/Rockxy/Models/UI/FilterCriteria.swift
@@ -28,14 +28,15 @@ struct FilterCriteria {
     var searchField: FilterField = .url
     var isSearchEnabled: Bool = true
     var sidebarDomain: String?
+    var sidebarPathPrefix: String?
     var sidebarApp: String?
     var sidebarScope: SidebarScope = .allTraffic
 
     var isEmpty: Bool {
         (!isSearchEnabled || searchText.isEmpty) && methods.isEmpty && statusCodes.isEmpty
             && contentTypes.isEmpty && domains.isEmpty && logLevels.isEmpty
-            && activeProtocolFilters.isEmpty && sidebarDomain == nil && sidebarApp == nil
-            && sidebarScope == .allTraffic
+            && activeProtocolFilters.isEmpty && sidebarDomain == nil
+            && sidebarPathPrefix == nil && sidebarApp == nil && sidebarScope == .allTraffic
     }
 
     var activeFilterCount: Int {
@@ -53,6 +54,9 @@ struct FilterCriteria {
             count += 1
         }
         if sidebarDomain != nil {
+            count += 1
+        }
+        if sidebarPathPrefix != nil {
             count += 1
         }
         if sidebarApp != nil {

--- a/Rockxy/Models/UI/SidebarItem.swift
+++ b/Rockxy/Models/UI/SidebarItem.swift
@@ -9,6 +9,7 @@ import Foundation
 /// log streams, and analytics sections.
 enum SidebarItem: Hashable, Codable {
     case domainNode(domain: String)
+    case domainPath(domain: String, pathPrefix: String)
     case app(name: String, bundleId: String?)
     case filter(name: String)
     case ruleGroup

--- a/Rockxy/Models/UI/WorkspaceState.swift
+++ b/Rockxy/Models/UI/WorkspaceState.swift
@@ -58,6 +58,7 @@ final class WorkspaceState: Identifiable {
     // Sidebar (per-workspace view of captured data)
     var domainTree: [DomainNode] = []
     var domainIndexMap: [String: Int] = [:]
+    var domainGroupingIndex = DomainGroupingIndex()
     var appNodes: [AppInfo] = []
     var appNodeIndexMap: [String: Int] = [:]
 
@@ -70,6 +71,7 @@ final class WorkspaceState: Identifiable {
         selectedLogEntry = nil
         domainTree.removeAll()
         domainIndexMap.removeAll()
+        domainGroupingIndex.removeAll()
         appNodes.removeAll()
         appNodeIndexMap.removeAll()
     }

--- a/Rockxy/RockxyApp.swift
+++ b/Rockxy/RockxyApp.swift
@@ -691,6 +691,15 @@ struct RockxyMenuCommands: Commands {
 
             Divider()
 
+            Button(String(localized: "Force Reset Rockxy Helper…")) {
+                let commandActions = actions
+                HelperRecoveryPresenter.presentForceReset {
+                    commandActions?.stopProxy()
+                }
+            }
+
+            Divider()
+
             Button(String(localized: "Homepage…")) {
                 openURL(ProjectLinks.homepage)
             }

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Filtering.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Filtering.swift
@@ -96,11 +96,12 @@ extension MainContentCoordinator {
                 return false
             }
             if let sidebarDomain = filterCriteria.sidebarDomain {
-                guard transaction.request.host.hasSuffix(sidebarDomain)
-                    || transaction.request.host == sidebarDomain else
-                {
+                guard DomainGrouping.host(transaction.request.host, matchesDomain: sidebarDomain) else {
                     return false
                 }
+            }
+            if !DomainGrouping.path(transaction.request.path, matchesPrefix: filterCriteria.sidebarPathPrefix) {
+                return false
             }
             if let sidebarApp = filterCriteria.sidebarApp {
                 guard transaction.clientApp == sidebarApp else {
@@ -211,11 +212,12 @@ extension MainContentCoordinator {
                 return false
             }
             if let sidebarDomain = workspace.filterCriteria.sidebarDomain {
-                guard transaction.request.host.hasSuffix(sidebarDomain)
-                    || transaction.request.host == sidebarDomain else
-                {
+                guard DomainGrouping.host(transaction.request.host, matchesDomain: sidebarDomain) else {
                     return false
                 }
+            }
+            if !DomainGrouping.path(transaction.request.path, matchesPrefix: workspace.filterCriteria.sidebarPathPrefix) {
+                return false
             }
             if let sidebarApp = workspace.filterCriteria.sidebarApp {
                 guard transaction.clientApp == sidebarApp else {

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProxyControl.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+ProxyControl.swift
@@ -360,23 +360,7 @@ extension MainContentCoordinator {
     }
 
     func updateDomainTree(for transaction: HTTPTransaction) {
-        let domain = transaction.request.host
-        guard !domain.isEmpty else {
-            return
-        }
-
-        if let index = domainIndexMap[domain] {
-            domainTree[index].requestCount += 1
-        } else {
-            let node = DomainNode(
-                id: domain,
-                domain: domain,
-                requestCount: 1,
-                children: []
-            )
-            domainIndexMap[domain] = domainTree.count
-            domainTree.append(node)
-        }
+        updateDomainTree(for: transaction, in: activeWorkspace)
     }
 
     func updateAppNodes(for transaction: HTTPTransaction) {

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Selection.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Selection.swift
@@ -22,6 +22,7 @@ extension MainContentCoordinator {
 
         guard let item else {
             filterCriteria.sidebarDomain = nil
+            filterCriteria.sidebarPathPrefix = nil
             filterCriteria.sidebarApp = nil
             filterCriteria.sidebarScope = .allTraffic
             recomputeFilteredTransactions()
@@ -31,46 +32,60 @@ extension MainContentCoordinator {
         switch item {
         case let .domainNode(domain):
             filterCriteria.sidebarDomain = domain
+            filterCriteria.sidebarPathPrefix = nil
+            filterCriteria.sidebarApp = nil
+            filterCriteria.sidebarScope = .allTraffic
+            recomputeFilteredTransactions()
+        case let .domainPath(domain, pathPrefix):
+            filterCriteria.sidebarDomain = domain
+            filterCriteria.sidebarPathPrefix = pathPrefix
             filterCriteria.sidebarApp = nil
             filterCriteria.sidebarScope = .allTraffic
             recomputeFilteredTransactions()
         case let .app(name, _):
             filterCriteria.sidebarDomain = nil
+            filterCriteria.sidebarPathPrefix = nil
             filterCriteria.sidebarApp = name
             filterCriteria.sidebarScope = .allTraffic
             recomputeFilteredTransactions()
         case .allApps,
              .allDomains:
             filterCriteria.sidebarDomain = nil
+            filterCriteria.sidebarPathPrefix = nil
             filterCriteria.sidebarApp = nil
             filterCriteria.sidebarScope = .allTraffic
             recomputeFilteredTransactions()
         case .allSaved:
             filterCriteria.sidebarDomain = nil
+            filterCriteria.sidebarPathPrefix = nil
             filterCriteria.sidebarApp = nil
             filterCriteria.sidebarScope = .saved
             selectedTransaction = nil
             recomputeFilteredTransactions()
         case .allPinned:
             filterCriteria.sidebarDomain = nil
+            filterCriteria.sidebarPathPrefix = nil
             filterCriteria.sidebarApp = nil
             filterCriteria.sidebarScope = .pinned
             selectedTransaction = nil
             recomputeFilteredTransactions()
         case let .pinnedTransaction(id):
             filterCriteria.sidebarDomain = nil
+            filterCriteria.sidebarPathPrefix = nil
             filterCriteria.sidebarApp = nil
             filterCriteria.sidebarScope = .pinned
             recomputeFilteredTransactions()
             selectedTransaction = transaction(for: id)
         case let .savedTransaction(id):
             filterCriteria.sidebarDomain = nil
+            filterCriteria.sidebarPathPrefix = nil
             filterCriteria.sidebarApp = nil
             filterCriteria.sidebarScope = .saved
             recomputeFilteredTransactions()
             selectedTransaction = transaction(for: id)
         default:
             filterCriteria.sidebarDomain = nil
+            filterCriteria.sidebarPathPrefix = nil
             filterCriteria.sidebarApp = nil
             filterCriteria.sidebarScope = .allTraffic
             recomputeFilteredTransactions()

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+SidebarMenu.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+SidebarMenu.swift
@@ -330,12 +330,8 @@ extension MainContentCoordinator {
     // MARK: - Sorting
 
     func sortDomainTreeAlphabetically() {
-        domainTree.sort { $0.domain.localizedCaseInsensitiveCompare($1.domain) == .orderedAscending }
+        refreshDomainTree(for: activeWorkspace, alphabetical: true)
         // Rebuild index map after sort
-        domainIndexMap.removeAll()
-        for (index, node) in domainTree.enumerated() {
-            domainIndexMap[node.domain] = index
-        }
         Self.logger.info("Sorted domain tree alphabetically")
     }
 
@@ -357,7 +353,14 @@ extension MainContentCoordinator {
     }
 
     func exportTransactionsForDomain(_ domain: String) {
-        let domainTransactions = transactions.filter { $0.request.host == domain }
+        exportTransactionsForDomain(domain, pathPrefix: nil)
+    }
+
+    func exportTransactionsForDomain(_ domain: String, pathPrefix: String?) {
+        let domainTransactions = transactions.filter {
+            DomainGrouping.host($0.request.host, matchesDomain: domain)
+                && DomainGrouping.path($0.request.path, matchesPrefix: pathPrefix)
+        }
         guard !domainTransactions.isEmpty else {
             return
         }
@@ -373,7 +376,11 @@ extension MainContentCoordinator {
         }
 
         let panel = NSSavePanel()
-        panel.nameFieldStringValue = "\(domain).har"
+        let suffix = pathPrefix?
+            .replacingOccurrences(of: "/", with: "-")
+            .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+        let fileName = suffix.map { "\(domain)-\($0).har" } ?? "\(domain).har"
+        panel.nameFieldStringValue = fileName
         panel.allowedContentTypes = [.har]
 
         guard panel.runModal() == .OK, let url = panel.url else {
@@ -434,29 +441,28 @@ extension MainContentCoordinator {
     // MARK: - Delete / Remove
 
     func removeDomainFromSidebar(_ domain: String) {
-        transactions.removeAll { $0.request.host == domain }
+        removeDomainFromSidebar(domain, pathPrefix: nil)
+    }
+
+    func removeDomainFromSidebar(_ domain: String, pathPrefix: String?) {
+        transactions.removeAll {
+            DomainGrouping.host($0.request.host, matchesDomain: domain)
+                && DomainGrouping.path($0.request.path, matchesPrefix: pathPrefix)
+        }
         rebuildObservedDomainsByApp()
 
-        if let index = domainIndexMap[domain] {
-            domainTree.remove(at: index)
-            domainIndexMap.removeValue(forKey: domain)
-            // Rebuild index map
-            domainIndexMap.removeAll()
-            for (i, node) in domainTree.enumerated() {
-                domainIndexMap[node.domain] = i
-            }
-        }
-
-        // Remove from app nodes' domain lists
-        for i in appNodes.indices {
-            appNodes[i].domains.removeAll { $0 == domain }
-        }
-
-        // Clear selection if it was this domain
-        if case .domainNode(domain) = sidebarSelection {
+        // Clear selection if it was removed by this action.
+        switch sidebarSelection {
+        case let .domainNode(selectedDomain) where selectedDomain == domain && pathPrefix == nil:
             sidebarSelection = nil
+        case let .domainPath(selectedDomain, selectedPath)
+            where selectedDomain == domain && selectedPath == pathPrefix:
+            sidebarSelection = nil
+        default:
+            break
         }
 
+        rebuildSidebarIndexes()
         recomputeFilteredTransactions()
         Self.logger.info("Removed domain from sidebar: \(domain)")
     }

--- a/Rockxy/Views/Main/Extensions/MainContentCoordinator+Workspaces.swift
+++ b/Rockxy/Views/Main/Extensions/MainContentCoordinator+Workspaces.swift
@@ -24,9 +24,10 @@ extension MainContentCoordinator {
     func updateAllWorkspaces(with batch: [HTTPTransaction]) {
         for workspace in workspaceStore.workspaces {
             for transaction in batch {
-                updateDomainTree(for: transaction, in: workspace)
+                updateDomainGroupingIndex(for: transaction, in: workspace)
                 updateAppNodes(for: transaction, in: workspace)
             }
+            refreshDomainTree(for: workspace)
             appendFilteredTransactions(batch, to: workspace)
         }
         TrafficDomainSnapshot.shared.update(appNodes: appNodes, domainTree: domainTree)
@@ -35,23 +36,33 @@ extension MainContentCoordinator {
     // MARK: - Per-Workspace Sidebar
 
     func updateDomainTree(for transaction: HTTPTransaction, in workspace: WorkspaceState) {
+        updateDomainGroupingIndex(for: transaction, in: workspace)
+        refreshDomainTree(for: workspace)
+    }
+
+    func updateDomainGroupingIndex(for transaction: HTTPTransaction, in workspace: WorkspaceState) {
         let domain = transaction.request.host
         guard !domain.isEmpty else {
             return
         }
 
         if let sidebarDomain = workspace.filterCriteria.sidebarDomain {
-            guard domain.hasSuffix(sidebarDomain) || domain == sidebarDomain else {
+            guard DomainGrouping.host(domain, matchesDomain: sidebarDomain) else {
+                return
+            }
+            if !DomainGrouping.path(transaction.request.path, matchesPrefix: workspace.filterCriteria.sidebarPathPrefix) {
                 return
             }
         }
 
-        if let index = workspace.domainIndexMap[domain] {
-            workspace.domainTree[index].requestCount += 1
-        } else {
-            let node = DomainNode(id: domain, domain: domain, requestCount: 1, children: [])
-            workspace.domainIndexMap[domain] = workspace.domainTree.count
-            workspace.domainTree.append(node)
+        workspace.domainGroupingIndex.add(transaction)
+    }
+
+    func refreshDomainTree(for workspace: WorkspaceState, alphabetical: Bool = false) {
+        workspace.domainTree = workspace.domainGroupingIndex.makeTree(alphabetical: alphabetical)
+        workspace.domainIndexMap.removeAll(keepingCapacity: true)
+        for (index, node) in workspace.domainTree.enumerated() {
+            workspace.domainIndexMap[node.selectionDomain] = index
         }
     }
 
@@ -81,12 +92,14 @@ extension MainContentCoordinator {
     func rebuildSidebarIndexes(for workspace: WorkspaceState) {
         workspace.domainTree.removeAll()
         workspace.domainIndexMap.removeAll()
+        workspace.domainGroupingIndex.removeAll()
         workspace.appNodes.removeAll()
         workspace.appNodeIndexMap.removeAll()
         for transaction in transactions {
-            updateDomainTree(for: transaction, in: workspace)
+            updateDomainGroupingIndex(for: transaction, in: workspace)
             updateAppNodes(for: transaction, in: workspace)
         }
+        refreshDomainTree(for: workspace)
         TrafficDomainSnapshot.shared.update(appNodes: appNodes, domainTree: domainTree)
     }
 

--- a/Rockxy/Views/Main/MainContentCoordinator.swift
+++ b/Rockxy/Views/Main/MainContentCoordinator.swift
@@ -400,21 +400,3 @@ struct AppInfo: Identifiable {
         name
     }
 }
-
-// MARK: - DomainNode
-
-/// Represents a single domain in the sidebar source list, tracking its aggregate request count.
-struct DomainNode: Identifiable, Hashable {
-    let id: String
-    let domain: String
-    var requestCount: Int
-    var children: [DomainNode]
-
-    static func == (lhs: DomainNode, rhs: DomainNode) -> Bool {
-        lhs.id == rhs.id
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(id)
-    }
-}

--- a/Rockxy/Views/Rules/BlockListWindowView.swift
+++ b/Rockxy/Views/Rules/BlockListWindowView.swift
@@ -43,24 +43,11 @@ final class BlockListViewModel {
         blockAction: BlockActionType,
         includeSubpaths: Bool
     ) {
-        let escapedPattern: String
-        switch matchType {
-        case .wildcard:
-            var pattern = NSRegularExpression.escapedPattern(for: urlPattern)
-                .replacingOccurrences(of: "\\*", with: ".*")
-                .replacingOccurrences(of: "\\?", with: ".")
-            if includeSubpaths {
-                if !pattern.hasSuffix(".*") {
-                    pattern += ".*"
-                }
-            } else {
-                pattern += "($|[?#])"
-            }
-            escapedPattern = pattern
-        case .regex:
-            escapedPattern = urlPattern
-        }
-
+        let escapedPattern = RulePatternBuilder.regexSource(
+            rawPattern: urlPattern,
+            matchType: matchType,
+            includeSubpaths: includeSubpaths
+        )
         let displayName = ruleName.isEmpty ? urlPattern : ruleName
 
         let rule = ProxyRule(

--- a/Rockxy/Views/Rules/ModifyHeaderEditorView.swift
+++ b/Rockxy/Views/Rules/ModifyHeaderEditorView.swift
@@ -41,20 +41,24 @@ final class EditableHeaderOperation: Identifiable {
     var headerValue: String
 
     var isValid: Bool {
-        guard !headerName.isEmpty else {
-            return false
+        validationMessage == nil
+    }
+
+    var validationMessage: String? {
+        guard !headerName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return String(localized: "Header Name is required")
         }
-        if type != .remove, headerValue.isEmpty {
-            return false
+        if type != .remove, headerValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return String(localized: "Header Value is required for \(type.rawValue.capitalized)")
         }
-        return true
+        return nil
     }
 
     func toHeaderOperation() -> HeaderOperation {
         HeaderOperation(
             type: type,
-            headerName: headerName,
-            headerValue: type == .remove ? nil : headerValue,
+            headerName: headerName.trimmingCharacters(in: .whitespacesAndNewlines),
+            headerValue: type == .remove ? nil : headerValue.trimmingCharacters(in: .whitespacesAndNewlines),
             phase: phase
         )
     }
@@ -72,11 +76,11 @@ struct ModifyHeaderEditorView: View {
     @Binding var operations: [EditableHeaderOperation]
 
     var allValid: Bool {
-        !operations.isEmpty && operations.allSatisfy(\.isValid)
+        !operations.isEmpty && operations.allSatisfy { $0.validationMessage == nil }
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: Theme.Layout.sectionSpacing) {
             helperText
 
             if operations.isEmpty {
@@ -92,6 +96,11 @@ struct ModifyHeaderEditorView: View {
     }
 
     // MARK: Private
+
+    private static let phaseWidth: CGFloat = 92
+    private static let operationWidth: CGFloat = 104
+    private static let minFieldWidth: CGFloat = 150
+    private static let removeWidth: CGFloat = 24
 
     private var helperText: some View {
         HStack(spacing: 6) {
@@ -116,7 +125,7 @@ struct ModifyHeaderEditorView: View {
     }
 
     private var operationsTable: some View {
-        VStack(spacing: 4) {
+        VStack(spacing: 6) {
             headerRow
 
             ForEach(operations) { operation in
@@ -126,17 +135,17 @@ struct ModifyHeaderEditorView: View {
     }
 
     private var headerRow: some View {
-        HStack(spacing: 4) {
+        HStack(spacing: 8) {
             Text(String(localized: "Phase"))
-                .frame(width: 70, alignment: .leading)
+                .frame(width: Self.phaseWidth, alignment: .leading)
             Text(String(localized: "Operation"))
-                .frame(width: 110, alignment: .leading)
+                .frame(width: Self.operationWidth, alignment: .leading)
             Text(String(localized: "Header Name"))
-                .frame(minWidth: 100, alignment: .leading)
+                .frame(minWidth: Self.minFieldWidth, maxWidth: .infinity, alignment: .leading)
             Text(String(localized: "Header Value"))
-                .frame(minWidth: 100, alignment: .leading)
+                .frame(minWidth: Self.minFieldWidth, maxWidth: .infinity, alignment: .leading)
             Spacer()
-                .frame(width: 24)
+                .frame(width: Self.removeWidth)
         }
         .font(.caption)
         .fontWeight(.semibold)
@@ -154,35 +163,30 @@ struct ModifyHeaderEditorView: View {
         }
         .buttonStyle(.borderless)
         .controlSize(.small)
-        .padding(.horizontal, 4)
+        .padding(.horizontal, 2)
     }
 
     @ViewBuilder private var validationMessages: some View {
-        let invalidOps = operations.enumerated().filter { !$0.element.isValid }
+        let invalidOps = operations.enumerated().compactMap { index, op -> (Int, String)? in
+            guard let message = op.validationMessage else {
+                return nil
+            }
+            return (index, message)
+        }
         if !invalidOps.isEmpty {
-            VStack(alignment: .leading, spacing: 2) {
-                ForEach(invalidOps, id: \.offset) { index, op in
-                    if op.headerName.isEmpty {
-                        Text(String(localized: "Row \(index + 1): Header Name is required"))
-                            .font(.caption)
-                            .foregroundStyle(.red)
-                    } else if op.type != .remove, op.headerValue.isEmpty {
-                        Text(
-                            String(
-                                localized: "Row \(index + 1): Header Value is required for \(op.type.rawValue.capitalized)"
-                            )
-                        )
+            VStack(alignment: .leading, spacing: 3) {
+                ForEach(invalidOps, id: \.0) { index, message in
+                    Text(String(localized: "Row \(index + 1): \(message)"))
                         .font(.caption)
                         .foregroundStyle(.red)
-                    }
                 }
             }
-            .padding(.horizontal, 4)
+            .padding(.horizontal, 2)
         }
     }
 
     private func operationRow(_ operation: EditableHeaderOperation) -> some View {
-        HStack(spacing: 4) {
+        HStack(spacing: 8) {
             Picker("", selection: Binding(
                 get: { operation.phase },
                 set: { operation.phase = $0 }
@@ -192,7 +196,8 @@ struct ModifyHeaderEditorView: View {
                 Text(String(localized: "Both")).tag(HeaderModifyPhase.both)
             }
             .labelsHidden()
-            .frame(width: 70)
+            .pickerStyle(.menu)
+            .frame(width: Self.phaseWidth)
             .controlSize(.small)
 
             Picker("", selection: Binding(
@@ -204,8 +209,8 @@ struct ModifyHeaderEditorView: View {
                 Text(String(localized: "Replace")).tag(HeaderOperationType.replace)
             }
             .labelsHidden()
-            .pickerStyle(.segmented)
-            .frame(width: 110)
+            .pickerStyle(.menu)
+            .frame(width: Self.operationWidth)
             .controlSize(.small)
 
             TextField(
@@ -218,9 +223,12 @@ struct ModifyHeaderEditorView: View {
             .font(.system(.body, design: .monospaced))
             .textFieldStyle(.roundedBorder)
             .controlSize(.small)
+            .frame(minWidth: Self.minFieldWidth)
 
             TextField(
-                String(localized: "Header value"),
+                operation.type == .remove
+                    ? String(localized: "Not used")
+                    : String(localized: "Header value"),
                 text: Binding(
                     get: { operation.headerValue },
                     set: { operation.headerValue = $0 }
@@ -231,6 +239,7 @@ struct ModifyHeaderEditorView: View {
             .controlSize(.small)
             .disabled(operation.type == .remove)
             .opacity(operation.type == .remove ? 0.4 : 1.0)
+            .frame(minWidth: Self.minFieldWidth)
 
             Button(role: .destructive) {
                 withAnimation(.easeInOut(duration: 0.2)) {
@@ -241,10 +250,9 @@ struct ModifyHeaderEditorView: View {
                     .font(.caption)
             }
             .buttonStyle(.borderless)
-            .frame(width: 24)
+            .frame(width: Self.removeWidth)
         }
-        .padding(.horizontal, 4)
-        .padding(.vertical, 2)
+        .padding(.horizontal, 2)
     }
 }
 

--- a/Rockxy/Views/Rules/ModifyHeaderWindowView.swift
+++ b/Rockxy/Views/Rules/ModifyHeaderWindowView.swift
@@ -5,6 +5,18 @@ import SwiftUI
 // modifyHeader rules with enable toggles, URL patterns, operation counts, phase
 // summary, and operation shorthand. Supports add/edit/delete with a modal sheet.
 
+// MARK: - ModifyHeaderEditorSession
+
+struct ModifyHeaderEditorSession: Identifiable {
+    enum Mode {
+        case create
+        case edit(rule: ProxyRule)
+    }
+
+    let id = UUID()
+    let mode: Mode
+}
+
 // MARK: - ModifyHeaderWindowViewModel
 
 @MainActor @Observable
@@ -12,6 +24,8 @@ final class ModifyHeaderWindowViewModel {
     // MARK: Internal
 
     private(set) var allRules: [ProxyRule] = []
+    var selectedRuleID: UUID?
+    var editorSession: ModifyHeaderEditorSession?
     var searchText = ""
 
     var modifyHeaderRules: [ProxyRule] {
@@ -58,8 +72,26 @@ final class ModifyHeaderWindowViewModel {
         }
     }
 
+    func presentNewRuleEditor() {
+        editorSession = ModifyHeaderEditorSession(mode: .create)
+    }
+
+    func presentEditorForSelection() {
+        guard let id = selectedRuleID,
+              let rule = allRules.first(where: { $0.id == id }) else
+        {
+            return
+        }
+        editorSession = ModifyHeaderEditorSession(mode: .edit(rule: rule))
+    }
+
+    func dismissEditor() {
+        editorSession = nil
+    }
+
     func addRule(_ rule: ProxyRule) {
         allRules.append(rule)
+        selectedRuleID = rule.id
         Task {
             let accepted = await RulePolicyGate.shared.addRule(rule)
             if !accepted {
@@ -73,12 +105,41 @@ final class ModifyHeaderWindowViewModel {
             return
         }
         allRules[index] = rule
+        selectedRuleID = rule.id
         Task { await RulePolicyGate.shared.updateRule(rule) }
     }
 
     func removeRule(id: UUID) {
         allRules.removeAll { $0.id == id }
+        if selectedRuleID == id {
+            selectedRuleID = nil
+        }
         Task { await RulePolicyGate.shared.removeRule(id: id) }
+    }
+
+    func saveRule(
+        existingRule: ProxyRule?,
+        ruleName: String,
+        urlPattern: String,
+        httpMethod: HTTPMethodFilter,
+        matchType: RuleMatchType,
+        includeSubpaths: Bool,
+        operations: [EditableHeaderOperation]
+    ) {
+        let rule = ModifyHeaderRuleBuilder.build(
+            existingRule: existingRule,
+            ruleName: ruleName,
+            rawPattern: urlPattern,
+            httpMethod: httpMethod,
+            matchType: matchType,
+            includeSubpaths: includeSubpaths,
+            operations: operations.toHeaderOperations()
+        )
+        if existingRule == nil {
+            addRule(rule)
+        } else {
+            updateRule(rule)
+        }
     }
 
     func operations(for rule: ProxyRule) -> [HeaderOperation] {
@@ -117,51 +178,56 @@ struct ModifyHeaderWindowView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            if !viewModel.modifyHeaderRules.isEmpty {
-                infoBar
-                Divider()
-            }
-            tableContent
+            toolbar
+            Divider()
+            infoBanner
+            Divider()
+            content
             Divider()
             bottomBar
         }
-        .frame(width: 780, height: 480)
-        .toolbar {
-            ToolbarItemGroup {
-                Button {
-                    editingRule = nil
-                    showEditSheet = true
-                } label: {
-                    Label(String(localized: "Add Rule"), systemImage: "plus")
-                }
-
-                TextField(String(localized: "Search"), text: $viewModel.searchText)
-                    .textFieldStyle(.roundedBorder)
-                    .frame(width: 160)
-            }
-        }
+        .frame(width: 860, height: 620)
         .task { await viewModel.refreshFromEngine() }
         .onReceive(NotificationCenter.default.publisher(for: .rulesDidChange)) { notification in
             viewModel.handleRulesDidChange(notification)
         }
-        .sheet(isPresented: $showEditSheet) {
-            ModifyHeaderEditSheet(existingRule: editingRule) { rule in
-                if editingRule != nil {
-                    viewModel.updateRule(rule)
+        .sheet(item: $viewModel.editorSession) { session in
+            ModifyHeaderEditSheet(session: session) { name, pattern, method, matchType, includeSubpaths, operations in
+                let existingRule: ProxyRule? = if case let .edit(rule) = session.mode {
+                    rule
                 } else {
-                    viewModel.addRule(rule)
+                    nil
                 }
+                viewModel.saveRule(
+                    existingRule: existingRule,
+                    ruleName: name,
+                    urlPattern: pattern,
+                    httpMethod: method,
+                    matchType: matchType,
+                    includeSubpaths: includeSubpaths,
+                    operations: operations
+                )
+                viewModel.dismissEditor()
             }
         }
     }
 
     // MARK: Private
 
-    @State private var selectedRuleID: UUID?
-    @State private var showEditSheet = false
-    @State private var editingRule: ProxyRule?
+    private var toolbar: some View {
+        HStack {
+            Text(String(localized: "Modify Headers"))
+                .font(.headline)
+            Spacer()
+            TextField(String(localized: "Search"), text: $viewModel.searchText)
+                .textFieldStyle(.roundedBorder)
+                .frame(width: 180)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+    }
 
-    @ViewBuilder private var tableContent: some View {
+    @ViewBuilder private var content: some View {
         if viewModel.modifyHeaderRules.isEmpty {
             VStack(alignment: .center, spacing: 8) {
                 Image(systemName: "list.bullet.header")
@@ -176,81 +242,69 @@ struct ModifyHeaderWindowView: View {
                     .multilineTextAlignment(.center)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(.horizontal, 24)
+            .padding(.top, 12)
         } else {
-            Table(viewModel.modifyHeaderRules, selection: $selectedRuleID) {
-                TableColumn("") { rule in
-                    Toggle("", isOn: Binding(
-                        get: { rule.isEnabled },
-                        set: { _ in viewModel.toggleRule(id: rule.id) }
-                    ))
-                    .toggleStyle(.switch)
-                    .labelsHidden()
-                    .controlSize(.small)
-                }
-                .width(40)
-
-                TableColumn(String(localized: "Name")) { rule in
-                    Text(rule.name)
-                        .fontWeight(.medium)
-                        .lineLimit(1)
-                        .opacity(rule.isEnabled ? 1.0 : 0.5)
-                }
-                .width(min: 100, ideal: 120)
-
-                TableColumn(String(localized: "URL Pattern")) { rule in
-                    Text(rule.matchCondition.urlPattern ?? "*")
-                        .font(.system(.body, design: .monospaced))
-                        .lineLimit(1)
-                        .help(rule.matchCondition.urlPattern ?? "*")
-                        .opacity(rule.isEnabled ? 1.0 : 0.5)
-                }
-                .width(min: 140, ideal: 180)
-
-                TableColumn(String(localized: "Ops")) { rule in
-                    Text("\(viewModel.operationCount(for: rule))")
-                        .font(.system(.body, design: .monospaced))
-                        .foregroundStyle(.secondary)
-                }
-                .width(40)
-
-                TableColumn(String(localized: "Phase")) { rule in
-                    Text(viewModel.phaseSummary(for: rule))
-                        .font(.caption)
-                        .fontWeight(.medium)
-                        .padding(.horizontal, 5)
-                        .padding(.vertical, 1)
-                        .background(Color.green.opacity(0.12))
-                        .foregroundStyle(.green)
-                        .clipShape(RoundedRectangle(cornerRadius: 3))
-                }
-                .width(60)
-
-                TableColumn(String(localized: "Summary")) { rule in
-                    Text(viewModel.operationSummary(for: rule))
-                        .font(.system(.caption, design: .monospaced))
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .help(viewModel.operationSummary(for: rule))
-                        .opacity(rule.isEnabled ? 1.0 : 0.5)
-                }
-            }
-            .contextMenu(forSelectionType: UUID.self) { ids in
-                if let id = ids.first {
-                    Button(String(localized: "Edit")) {
-                        editingRule = viewModel.allRules.first { $0.id == id }
-                        showEditSheet = true
+            VStack(spacing: 0) {
+                columnHeader
+                Divider()
+                List(selection: $viewModel.selectedRuleID) {
+                    ForEach(viewModel.modifyHeaderRules) { rule in
+                        ModifyHeaderRuleRow(
+                            rule: rule,
+                            operationCount: viewModel.operationCount(for: rule),
+                            phaseSummary: viewModel.phaseSummary(for: rule),
+                            operationSummary: viewModel.operationSummary(for: rule)
+                        ) {
+                            viewModel.toggleRule(id: rule.id)
+                        }
+                        .tag(rule.id)
                     }
-                    Divider()
-                    Button(String(localized: "Delete"), role: .destructive) {
-                        viewModel.removeRule(id: id)
-                        selectedRuleID = nil
-                    }
+                }
+                .listStyle(.inset(alternatesRowBackgrounds: true))
+                .contextMenu(forSelectionType: UUID.self) { _ in
+                    contextMenuItems
+                } primaryAction: { _ in
+                    viewModel.presentEditorForSelection()
                 }
             }
         }
     }
 
-    private var infoBar: some View {
+    private var columnHeader: some View {
+        HStack(spacing: 10) {
+            Spacer().frame(width: 24)
+            Text(String(localized: "Name"))
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .frame(width: 190, alignment: .leading)
+            Text(String(localized: "Method"))
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .frame(width: 70, alignment: .leading)
+            Text(String(localized: "Matching Rule"))
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Text(String(localized: "Ops"))
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .frame(width: 42, alignment: .trailing)
+            Text(String(localized: "Phase"))
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .frame(width: 72, alignment: .leading)
+            Text(String(localized: "Summary"))
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .frame(width: 150, alignment: .leading)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 6)
+        .background(.background.tertiary)
+    }
+
+    private var infoBanner: some View {
         HStack(spacing: 6) {
             Image(systemName: "info.circle")
                 .foregroundStyle(.secondary)
@@ -263,60 +317,148 @@ struct ModifyHeaderWindowView: View {
             .foregroundStyle(.secondary)
             Spacer()
         }
-        .padding(.horizontal, 12)
+        .padding(.horizontal, 16)
         .padding(.vertical, 8)
         .background(.quaternary.opacity(0.5))
     }
 
     private var bottomBar: some View {
-        HStack(spacing: 0) {
+        HStack(spacing: 8) {
             Button {
-                editingRule = nil
-                showEditSheet = true
+                viewModel.presentNewRuleEditor()
             } label: {
                 Image(systemName: "plus")
-                    .frame(width: 28, height: 22)
             }
             .buttonStyle(.borderless)
+            .help(String(localized: "New Rule"))
 
             Button {
-                guard let id = selectedRuleID else {
+                guard let id = viewModel.selectedRuleID else {
                     return
                 }
                 viewModel.removeRule(id: id)
-                selectedRuleID = nil
             } label: {
                 Image(systemName: "minus")
-                    .frame(width: 28, height: 22)
             }
             .buttonStyle(.borderless)
-            .disabled(selectedRuleID == nil)
+            .disabled(viewModel.selectedRuleID == nil)
+            .help(String(localized: "Delete Rule"))
 
-            Spacer()
-
-            Menu(String(localized: "Presets")) {
-                Button(String(localized: "Add CORS Headers")) {
-                    viewModel.addRule(HeaderModifyPresets.corsHeaders())
-                }
-                Button(String(localized: "Remove Authorization")) {
-                    viewModel.addRule(HeaderModifyPresets.removeAuthorization())
-                }
-                Button(String(localized: "Strip Server Header")) {
-                    viewModel.addRule(HeaderModifyPresets.stripServerHeader())
-                }
-            }
-            .menuStyle(.borderlessButton)
-            .controlSize(.small)
-            .fixedSize()
+            Divider()
+                .frame(height: 16)
 
             Text(
                 "\(viewModel.ruleCount) \(viewModel.ruleCount == 1 ? String(localized: "rule") : String(localized: "rules"))"
             )
             .font(.caption)
             .foregroundStyle(.secondary)
+
+            Spacer()
+
+            presetsMenu
         }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 4)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    @ViewBuilder private var contextMenuItems: some View {
+        Button(String(localized: "Edit…")) {
+            viewModel.presentEditorForSelection()
+        }
+        .keyboardShortcut(.return, modifiers: .command)
+
+        Divider()
+
+        Button(String(localized: "Delete"), role: .destructive) {
+            if let id = viewModel.selectedRuleID {
+                viewModel.removeRule(id: id)
+            }
+        }
+        .keyboardShortcut(.delete, modifiers: .command)
+    }
+
+    private var presetsMenu: some View {
+        Menu {
+            Button(String(localized: "Add CORS Headers")) {
+                viewModel.addRule(HeaderModifyPresets.corsHeaders())
+            }
+            Button(String(localized: "Remove Authorization")) {
+                viewModel.addRule(HeaderModifyPresets.removeAuthorization())
+            }
+            Button(String(localized: "Strip Server Header")) {
+                viewModel.addRule(HeaderModifyPresets.stripServerHeader())
+            }
+        } label: {
+            Text(String(localized: "Presets"))
+            Image(systemName: "chevron.down")
+                .font(.caption2)
+        }
+        .menuStyle(.borderlessButton)
+    }
+}
+
+// MARK: - ModifyHeaderRuleRow
+
+private struct ModifyHeaderRuleRow: View {
+    let rule: ProxyRule
+    let operationCount: Int
+    let phaseSummary: String
+    let operationSummary: String
+    let onToggle: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Toggle("", isOn: Binding(
+                get: { rule.isEnabled },
+                set: { _ in onToggle() }
+            ))
+            .toggleStyle(.switch)
+            .labelsHidden()
+            .controlSize(.small)
+
+            Text(rule.name)
+                .font(.system(size: 12, weight: .medium))
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(width: 190, alignment: .leading)
+
+            Text(rule.matchCondition.method ?? "ANY")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(width: 70, alignment: .leading)
+
+            Text(rule.matchCondition.urlPattern ?? ".*")
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .help(rule.matchCondition.urlPattern ?? ".*")
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            Text("\(operationCount)")
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .frame(width: 42, alignment: .trailing)
+
+            Text(phaseSummary)
+                .font(.caption.weight(.medium))
+                .padding(.horizontal, 5)
+                .padding(.vertical, 1)
+                .background(Color.green.opacity(0.12))
+                .foregroundStyle(.green)
+                .clipShape(RoundedRectangle(cornerRadius: 3))
+                .frame(width: 72, alignment: .leading)
+
+            Text(operationSummary)
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .help(operationSummary)
+                .frame(width: 150, alignment: .leading)
+        }
+        .padding(.vertical, 2)
+        .opacity(rule.isEnabled ? 1.0 : 0.5)
     }
 }
 
@@ -325,45 +467,77 @@ struct ModifyHeaderWindowView: View {
 private struct ModifyHeaderEditSheet: View {
     // MARK: Lifecycle
 
-    init(existingRule: ProxyRule?, onSave: @escaping (ProxyRule) -> Void) {
-        self.existingRule = existingRule
+    init(
+        session: ModifyHeaderEditorSession,
+        onSave: @escaping (String, String, HTTPMethodFilter, RuleMatchType, Bool, [EditableHeaderOperation]) -> Void
+    ) {
+        self.session = session
         self.onSave = onSave
 
-        if let rule = existingRule {
+        switch session.mode {
+        case .create:
+            _name = State(initialValue: "")
+            _urlPattern = State(initialValue: "*")
+            _httpMethod = State(initialValue: .any)
+            _matchType = State(initialValue: .wildcard)
+            _includeSubpaths = State(initialValue: true)
+            _operations = State(initialValue: [EditableHeaderOperation()])
+        case let .edit(rule):
             _name = State(initialValue: rule.name)
-            _urlPattern = State(initialValue: rule.matchCondition.urlPattern ?? "")
-            _method = State(initialValue: rule.matchCondition.method ?? "")
+            _urlPattern = State(initialValue: rule.matchCondition.urlPattern ?? ".*")
+            let normalizedMethod = rule.matchCondition.method?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .uppercased()
+            _httpMethod = State(
+                initialValue: normalizedMethod.flatMap(HTTPMethodFilter.init(rawValue:)) ?? .any
+            )
+            _matchType = State(initialValue: .regex)
+            _includeSubpaths = State(initialValue: false)
             if case let .modifyHeader(ops) = rule.action {
                 _operations = State(initialValue: [EditableHeaderOperation].from(ops))
+            } else {
+                _operations = State(initialValue: [EditableHeaderOperation()])
             }
         }
     }
 
     // MARK: Internal
 
-    let existingRule: ProxyRule?
-    let onSave: (ProxyRule) -> Void
+    let session: ModifyHeaderEditorSession
+    let onSave: (String, String, HTTPMethodFilter, RuleMatchType, Bool, [EditableHeaderOperation]) -> Void
 
     var body: some View {
         VStack(spacing: 0) {
-            Form {
-                Section(String(localized: "Rule Info")) {
-                    TextField(String(localized: "Name"), text: $name)
+            VStack(alignment: .leading, spacing: Theme.Layout.sectionSpacing) {
+                formRow(String(localized: "Name:")) {
+                    TextField("", text: $name, prompt: Text(String(localized: "Untitled")))
+                        .textFieldStyle(.roundedBorder)
                 }
 
-                Section(String(localized: "Match Condition")) {
-                    TextField(String(localized: "URL Pattern (regex)"), text: $urlPattern)
+                formRow(String(localized: "Matching Rule:")) {
+                    TextField("", text: $urlPattern, prompt: Text("https://example.com/api/*"))
+                        .textFieldStyle(.roundedBorder)
                         .font(.system(.body, design: .monospaced))
-                    TextField(String(localized: "HTTP Method"), text: $method)
-                        .textCase(.uppercase)
                 }
 
-                Section(String(localized: "Header Operations")) {
-                    ModifyHeaderEditorView(operations: $operations)
+                methodAndMatchRow
+
+                conditionalFields
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(String(localized: "Header Operations"))
+                        .font(.system(size: 13, weight: .medium))
+                    ScrollView {
+                        ModifyHeaderEditorView(operations: $operations)
+                    }
+                    .frame(maxHeight: 300)
                 }
             }
-            .formStyle(.grouped)
+            .padding(.horizontal, 24)
+            .padding(.top, 12)
+            .padding(.bottom, 12)
 
+            Divider()
             HStack {
                 Spacer()
                 Button(String(localized: "Cancel")) {
@@ -371,47 +545,119 @@ private struct ModifyHeaderEditSheet: View {
                 }
                 .keyboardShortcut(.cancelAction)
 
-                Button(existingRule != nil ? String(localized: "Save") : String(localized: "Add Rule")) {
-                    saveRule()
+                Button(isEditing ? String(localized: "Save") : String(localized: "Add")) {
+                    onSave(
+                        trimmedName,
+                        trimmedPattern,
+                        httpMethod,
+                        matchType,
+                        matchType == .wildcard ? includeSubpaths : false,
+                        operations
+                    )
+                    dismiss()
                 }
                 .keyboardShortcut(.defaultAction)
                 .disabled(!isValid)
             }
-            .padding()
+            .padding(.horizontal, 24)
+            .padding(.vertical, 8)
         }
-        .frame(width: 560, height: 480)
+        .frame(width: 680)
+        .fixedSize(horizontal: false, vertical: true)
     }
 
     // MARK: Private
+
+    private static let labelWidth: CGFloat = 110
 
     @Environment(\.dismiss) private var dismiss
 
     @State private var name = ""
     @State private var urlPattern = ""
-    @State private var method = ""
+    @State private var httpMethod: HTTPMethodFilter
+    @State private var matchType: RuleMatchType
+    @State private var includeSubpaths: Bool
     @State private var operations: [EditableHeaderOperation] = [EditableHeaderOperation()]
 
+    private var isEditing: Bool {
+        if case .edit = session.mode {
+            return true
+        }
+        return false
+    }
+
+    private var trimmedName: String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var trimmedPattern: String {
+        urlPattern.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     private var isValid: Bool {
-        !name.isEmpty
+        !trimmedPattern.isEmpty
             && !operations.isEmpty
             && operations.allSatisfy(\.isValid)
     }
 
-    private func saveRule() {
-        let condition = RuleMatchCondition(
-            urlPattern: urlPattern.isEmpty ? nil : urlPattern,
-            method: method.isEmpty ? nil : method.uppercased()
-        )
-        let action = RuleAction.modifyHeader(operations: operations.toHeaderOperations())
-        let rule = ProxyRule(
-            id: existingRule?.id ?? UUID(),
-            name: name,
-            isEnabled: existingRule?.isEnabled ?? true,
-            matchCondition: condition,
-            action: action,
-            priority: existingRule?.priority ?? 0
-        )
-        onSave(rule)
-        dismiss()
+    private var methodAndMatchRow: some View {
+        HStack(spacing: 8) {
+            Spacer()
+                .frame(width: Self.labelWidth + Theme.Layout.sectionSpacing)
+            Picker("", selection: $httpMethod) {
+                ForEach(HTTPMethodFilter.allCases, id: \.self) { method in
+                    Text(method.rawValue).tag(method)
+                }
+            }
+            .pickerStyle(.menu)
+            .labelsHidden()
+            .accessibilityLabel(String(localized: "HTTP Method"))
+            .frame(width: 90)
+
+            Picker("", selection: $matchType) {
+                ForEach(RuleMatchType.allCases, id: \.self) { type in
+                    Text(type.rawValue).tag(type)
+                }
+            }
+            .pickerStyle(.menu)
+            .labelsHidden()
+            .accessibilityLabel(String(localized: "Match Type"))
+            .frame(width: 175)
+
+            if matchType == .wildcard {
+                Text(String(localized: "Support wildcard * and ?."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    @ViewBuilder private var conditionalFields: some View {
+        if matchType == .wildcard {
+            HStack(spacing: 8) {
+                Spacer()
+                    .frame(width: Self.labelWidth + Theme.Layout.sectionSpacing)
+                Toggle(String(localized: "Include all subpaths of this URL"), isOn: $includeSubpaths)
+                    .toggleStyle(.checkbox)
+                    .font(.system(size: 13))
+            }
+        }
+    }
+
+    private func formRow(
+        _ label: String,
+        @ViewBuilder content: () -> some View
+    )
+        -> some View
+    {
+        HStack(alignment: .top, spacing: Theme.Layout.sectionSpacing) {
+            Text(label)
+                .font(.system(size: 13))
+                .frame(width: Self.labelWidth, alignment: .trailing)
+                .padding(.top, 4)
+            VStack(alignment: .leading, spacing: 4) {
+                content()
+            }
+        }
     }
 }

--- a/Rockxy/Views/Settings/AdvancedProxySettingsView.swift
+++ b/Rockxy/Views/Settings/AdvancedProxySettingsView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import os
 import ServiceManagement
 import SwiftUI
@@ -433,19 +434,6 @@ struct AdvancedProxySettingsView: View {
                 }
                 .disabled(helperManager.isBusy)
 
-                Button(String(localized: "Reset Registration")) {
-                    Task {
-                        do {
-                            try await helperManager.forceResetRegistration()
-                        } catch {
-                            Self.logger.error(
-                                "Failed to force-reset helper: \(error.localizedDescription)"
-                            )
-                        }
-                    }
-                }
-                .disabled(helperManager.isBusy)
-
             case .installedCompatible:
                 Button(String(localized: "Check Again")) {
                     Task { await helperManager.checkStatus() }
@@ -503,6 +491,13 @@ struct AdvancedProxySettingsView: View {
                     .disabled(helperManager.isBusy)
                 }
             }
+
+            Button(role: .destructive) {
+                HelperRecoveryPresenter.presentForceReset()
+            } label: {
+                Text(String(localized: "Force Reset…"))
+            }
+            .disabled(helperManager.isBusy)
         }
     }
 

--- a/Rockxy/Views/Settings/AdvancedSettingsTab.swift
+++ b/Rockxy/Views/Settings/AdvancedSettingsTab.swift
@@ -107,18 +107,6 @@ struct AdvancedSettingsTab: View {
                                     Task { await helperManager.checkStatus() }
                                 }
                                 .disabled(helperManager.isBusy)
-                                Button(String(localized: "Reset Registration")) {
-                                    Task {
-                                        do {
-                                            try await helperManager.forceResetRegistration()
-                                        } catch {
-                                            Self.logger.error(
-                                                "Failed to force-reset helper: \(error.localizedDescription)"
-                                            )
-                                        }
-                                    }
-                                }
-                                .disabled(helperManager.isBusy)
                             case .installedCompatible:
                                 Button(String(localized: "Check Again")) {
                                     Task { await helperManager.checkStatus() }
@@ -168,6 +156,13 @@ struct AdvancedSettingsTab: View {
                                     .disabled(helperManager.isBusy)
                                 }
                             }
+
+                            Button(role: .destructive) {
+                                HelperRecoveryPresenter.presentForceReset()
+                            } label: {
+                                Text(String(localized: "Force Reset…"))
+                            }
+                            .disabled(helperManager.isBusy)
                         }
                     }
                 }

--- a/Rockxy/Views/Settings/HelperRecoveryPresenter.swift
+++ b/Rockxy/Views/Settings/HelperRecoveryPresenter.swift
@@ -1,0 +1,151 @@
+import AppKit
+import ServiceManagement
+
+@MainActor
+enum HelperRecoveryPresenter {
+    // MARK: Internal
+
+    static func presentForceReset(stopCapture: (() -> Void)? = nil) {
+        let confirmation = NSAlert()
+        confirmation.alertStyle = .critical
+        confirmation.messageText = String(localized: "Force reset the Rockxy Helper?")
+        confirmation.informativeText = String(
+            localized: """
+            Rockxy will stop capture, request administrator approval, remove stale launchd and privileged helper files, \
+            then recheck the helper. System proxy settings may be restored during the reset.
+
+            Use this only when install, uninstall, and recheck are stuck.
+            """
+        )
+        confirmation.addButton(withTitle: String(localized: "Force Reset"))
+        confirmation.addButton(withTitle: String(localized: "Cancel"))
+
+        guard confirmation.runModal() == .alertFirstButtonReturn else {
+            return
+        }
+
+        runForceReset(stopCapture: stopCapture, resetBackgroundItems: false)
+    }
+
+    // MARK: Private
+
+    private static func runForceReset(
+        stopCapture: (() -> Void)?,
+        resetBackgroundItems: Bool
+    ) {
+        NotificationCenter.default.post(name: .stopProxyRequested, object: nil)
+        stopCapture?()
+
+        Task { @MainActor in
+            do {
+                try await Task.sleep(nanoseconds: 750_000_000)
+                let result = try await HelperManager.shared.forceRemoveHelper(
+                    resetBackgroundItems: resetBackgroundItems
+                )
+                await ReadinessCoordinator.shared.deepRefresh()
+                presentSuccess(result: result)
+            } catch {
+                presentFailure(
+                    error: error,
+                    stopCapture: stopCapture,
+                    canTryBackgroundItemsReset: !resetBackgroundItems
+                )
+            }
+        }
+    }
+
+    private static func presentSuccess(result: HelperManager.ForceRemoveResult) {
+        let alert = NSAlert()
+        alert.alertStyle = .informational
+        alert.messageText = String(localized: "Helper reset complete")
+        alert.informativeText = String(
+            localized: """
+            \(result.localizedSummary)
+
+            Install the helper again, then approve Rockxy in System Settings > Login Items if macOS asks.
+            """
+        )
+        alert.addButton(withTitle: String(localized: "Install Helper"))
+        alert.addButton(withTitle: String(localized: "Open Login Items"))
+        alert.addButton(withTitle: String(localized: "OK"))
+
+        switch alert.runModal() {
+        case .alertFirstButtonReturn:
+            Task { @MainActor in
+                do {
+                    try await HelperManager.shared.install()
+                    await ReadinessCoordinator.shared.deepRefresh()
+                    if HelperManager.shared.status == .requiresApproval {
+                        SMAppService.openSystemSettingsLoginItems()
+                    }
+                } catch {
+                    presentInstallFailure(error)
+                }
+            }
+        case .alertSecondButtonReturn:
+            SMAppService.openSystemSettingsLoginItems()
+        default:
+            break
+        }
+    }
+
+    private static func presentFailure(
+        error: Error,
+        stopCapture: (() -> Void)?,
+        canTryBackgroundItemsReset: Bool
+    ) {
+        let alert = NSAlert()
+        alert.alertStyle = .critical
+        alert.messageText = String(localized: "Helper reset failed")
+        alert.informativeText = error.localizedDescription
+
+        if canTryBackgroundItemsReset {
+            alert.addButton(withTitle: String(localized: "Try Background Items Reset"))
+        }
+        alert.addButton(withTitle: String(localized: "Copy Details"))
+        alert.addButton(withTitle: String(localized: "OK"))
+
+        let response = alert.runModal()
+        if canTryBackgroundItemsReset, response == .alertFirstButtonReturn {
+            presentBackgroundItemsResetConfirmation(stopCapture: stopCapture)
+            return
+        }
+
+        let copyDetailsResponse: NSApplication.ModalResponse = canTryBackgroundItemsReset
+            ? .alertSecondButtonReturn
+            : .alertFirstButtonReturn
+        if response == copyDetailsResponse {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(error.localizedDescription, forType: .string)
+        }
+    }
+
+    private static func presentBackgroundItemsResetConfirmation(stopCapture: (() -> Void)?) {
+        let alert = NSAlert()
+        alert.alertStyle = .critical
+        alert.messageText = String(localized: "Reset macOS Login and Background Items data?")
+        alert.informativeText = String(
+            localized: """
+            This runs sfltool resetbtm after removing Rockxy helper files. It can reset Background Items state \
+            for other apps, so use it only when the normal force reset cannot recover Rockxy.
+            """
+        )
+        alert.addButton(withTitle: String(localized: "Reset Background Items"))
+        alert.addButton(withTitle: String(localized: "Cancel"))
+
+        guard alert.runModal() == .alertFirstButtonReturn else {
+            return
+        }
+
+        runForceReset(stopCapture: stopCapture, resetBackgroundItems: true)
+    }
+
+    private static func presentInstallFailure(_ error: Error) {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = String(localized: "Helper install failed")
+        alert.informativeText = error.localizedDescription
+        alert.addButton(withTitle: String(localized: "OK"))
+        alert.runModal()
+    }
+}

--- a/Rockxy/Views/Sidebar/SidebarView.swift
+++ b/Rockxy/Views/Sidebar/SidebarView.swift
@@ -136,6 +136,7 @@ struct SidebarView: View {
 
     @State private var sidebarFilterText = ""
     @State private var isAddFavoritePresented = false
+    @State private var expandedDomainNodeIDs: Set<String> = []
 
     private var sidebarBinding: Binding<SidebarItem?> {
         Binding(
@@ -280,6 +281,15 @@ struct SidebarView: View {
             }
             .tag(item)
             .contextMenu { domainContextMenu(domain) }
+        case let .domainPath(domain, pathPrefix):
+            Label {
+                Text("\(domain)\(pathPrefix)")
+                    .lineLimit(1)
+            } icon: {
+                Image(systemName: "link")
+            }
+            .tag(item)
+            .contextMenu { domainContextMenu(domain, pathPrefix: pathPrefix) }
         case let .app(name, _):
             Label {
                 Text(name)
@@ -299,44 +309,109 @@ struct SidebarView: View {
 
     // MARK: - Helpers
 
-    @ViewBuilder
-    private func domainRow(_ node: DomainNode) -> some View {
+    private func domainRow(_ node: DomainNode) -> AnyView {
         if node.children.isEmpty {
-            domainLabel(node.domain, requestCount: node.requestCount)
+            return AnyView(domainLabel(node))
         } else {
-            DisclosureGroup {
-                ForEach(node.children) { child in
-                    domainLabel(child.domain, requestCount: child.requestCount)
+            return AnyView(
+                DisclosureGroup(isExpanded: domainExpansionBinding(for: node.id)) {
+                    ForEach(node.children) { child in
+                        domainRow(child)
+                    }
+                } label: {
+                    domainLabel(node)
                 }
-            } label: {
-                domainLabel(node.domain, requestCount: node.requestCount)
-            }
+            )
         }
     }
 
     private func domainLabel(_ domain: String, requestCount: Int) -> some View {
+        domainLabel(
+            DomainNode(
+                id: domain,
+                domain: domain,
+                requestCount: requestCount,
+                children: [],
+                filterDomain: domain
+            )
+        )
+    }
+
+    private func domainLabel(_ node: DomainNode) -> some View {
         Label {
-            HStack(spacing: 4) {
-                Text(domain)
-                if coordinator.isSSLProxyingEnabled(for: domain) {
+            HStack(spacing: 5) {
+                Text(node.domain)
+                    .foregroundStyle(node.kind == .path ? .secondary : .primary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+
+                if coordinator.isSSLProxyingEnabled(for: node.selectionDomain), node.kind != .path {
                     Image(systemName: "lock.shield.fill")
                         .font(.caption2)
                         .foregroundStyle(.green)
                 }
+
+                if node.errorCount > 0 {
+                    Label("\(node.errorCount)", systemImage: "exclamationmark.triangle.fill")
+                        .labelStyle(.titleAndIcon)
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                        .help(String(localized: "\(node.errorCount) failed or error responses"))
+                }
             }
         } icon: {
-            Image(systemName: "globe")
+            Image(systemName: domainIconName(for: node.kind))
+                .foregroundStyle(node.kind == .path ? .secondary : .primary)
         }
-        .badge(requestCount)
-        .tag(SidebarItem.domainNode(domain: domain))
-        .contextMenu { domainContextMenu(domain) }
+        .badge(node.requestCount)
+        .tag(sidebarItem(for: node))
+        .contextMenu { domainContextMenu(node.selectionDomain, pathPrefix: node.pathPrefix) }
+        .help(domainHelpText(for: node))
+    }
+
+    private func domainExpansionBinding(for nodeID: String) -> Binding<Bool> {
+        Binding {
+            expandedDomainNodeIDs.contains(nodeID)
+        } set: { isExpanded in
+            if isExpanded {
+                expandedDomainNodeIDs.insert(nodeID)
+            } else {
+                expandedDomainNodeIDs.remove(nodeID)
+            }
+        }
+    }
+
+    private func sidebarItem(for node: DomainNode) -> SidebarItem {
+        if let pathPrefix = node.pathPrefix {
+            return .domainPath(domain: node.selectionDomain, pathPrefix: pathPrefix)
+        }
+        return .domainNode(domain: node.selectionDomain)
+    }
+
+    private func domainIconName(for kind: DomainNode.Kind) -> String {
+        switch kind {
+        case .domain:
+            "globe"
+        case .host:
+            "network"
+        case .path:
+            "link"
+        }
+    }
+
+    private func domainHelpText(for node: DomainNode) -> String {
+        if let pathPrefix = node.pathPrefix {
+            return "\(node.selectionDomain)\(pathPrefix)"
+        }
+        return node.selectionDomain
     }
 
     // MARK: - Context Menus
 
     @ViewBuilder
-    private func domainContextMenu(_ domain: String) -> some View {
-        let item = SidebarItem.domainNode(domain: domain)
+    private func domainContextMenu(_ domain: String, pathPrefix: String? = nil) -> some View {
+        let item = pathPrefix.map { SidebarItem.domainPath(domain: domain, pathPrefix: $0) }
+            ?? SidebarItem.domainNode(domain: domain)
         let isPinned = coordinator.isFavorite(item)
 
         Button {
@@ -351,7 +426,9 @@ struct SidebarView: View {
         Button {
             var filter = FilterCriteria.empty
             filter.sidebarDomain = domain
-            let ws = coordinator.workspaceStore.createWorkspace(title: domain, filter: filter)
+            filter.sidebarPathPrefix = pathPrefix
+            let title = pathPrefix.map { "\(domain)\($0)" } ?? domain
+            let ws = coordinator.workspaceStore.createWorkspace(title: title, filter: filter)
             coordinator.recomputeFilteredTransactions(for: ws)
             coordinator.rebuildSidebarIndexes(for: ws)
         } label: {
@@ -445,12 +522,15 @@ struct SidebarView: View {
 
         Menu {
             Button {
-                coordinator.copyDomainToClipboard(domain)
+                coordinator.copyDomainToClipboard(pathPrefix.map { "\(domain)\($0)" } ?? domain)
             } label: {
-                Label(String(localized: "Copy Domain"), systemImage: "doc.on.doc")
+                Label(
+                    pathPrefix == nil ? String(localized: "Copy Domain") : String(localized: "Copy Path Filter"),
+                    systemImage: "doc.on.doc"
+                )
             }
             Button {
-                coordinator.exportTransactionsForDomain(domain)
+                coordinator.exportTransactionsForDomain(domain, pathPrefix: pathPrefix)
             } label: {
                 Label(String(localized: "Export Transactions"), systemImage: "square.and.arrow.up")
             }
@@ -461,7 +541,7 @@ struct SidebarView: View {
         Divider()
 
         Button(role: .destructive) {
-            coordinator.removeDomainFromSidebar(domain)
+            coordinator.removeDomainFromSidebar(domain, pathPrefix: pathPrefix)
         } label: {
             Label(String(localized: "Delete"), systemImage: "trash")
         }

--- a/Rockxy/Views/Toolbar/ActiveFilterSummaryBar.swift
+++ b/Rockxy/Views/Toolbar/ActiveFilterSummaryBar.swift
@@ -17,10 +17,12 @@ struct ActiveFilterSummaryBar: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 6) {
                     if let domain = coordinator.filterCriteria.sidebarDomain {
+                        let pathPrefix = coordinator.filterCriteria.sidebarPathPrefix ?? ""
                         FilterChip(
-                            label: String(localized: "Domain: \(domain)"),
+                            label: String(localized: "Domain: \(domain)\(pathPrefix)"),
                             onRemove: {
                                 coordinator.filterCriteria.sidebarDomain = nil
+                                coordinator.filterCriteria.sidebarPathPrefix = nil
                                 coordinator.sidebarSelection = nil
                                 coordinator.recomputeFilteredTransactions()
                             }
@@ -111,6 +113,7 @@ struct ActiveFilterSummaryBar: View {
 
     private var hasActiveFilters: Bool {
         coordinator.filterCriteria.sidebarDomain != nil
+            || coordinator.filterCriteria.sidebarPathPrefix != nil
             || coordinator.filterCriteria.sidebarApp != nil
             || coordinator.filterCriteria.sidebarScope == .saved
             || coordinator.filterCriteria.sidebarScope == .pinned

--- a/RockxyTests/Core/ProxyEngine/HelperManagerTests.swift
+++ b/RockxyTests/Core/ProxyEngine/HelperManagerTests.swift
@@ -365,11 +365,11 @@ struct HelperManagerTests {
         #expect(probe == .xpcFailure)
     }
 
-    @Test("decideRecovery returns attemptReRegistration for xpcFailure")
+    @Test("decideRecovery surfaces unreachable for xpcFailure")
     @MainActor
     func decideRecoveryXpcFailure() {
         let action = HelperManager.decideRecovery(probe: .xpcFailure)
-        #expect(action == .attemptReRegistration)
+        #expect(action == .surfaceUnreachable)
     }
 
     // MARK: - Subtype-Only Change Detection
@@ -464,6 +464,84 @@ struct HelperManagerTests {
         #expect(message.contains("Login Items"))
     }
 
+    // MARK: - Hard Force Remove Script
+
+    @Test("hard force remove script clears launchd and privileged helper locations")
+    func hardForceRemoveScriptClearsHelperArtifacts() {
+        let script = HelperManager.forceRemoveShellScript(
+            identity: makeForceRemoveIdentity(),
+            resetBackgroundItems: false
+        )
+
+        #expect(script.contains("/bin/launchctl bootout system/'\(TestIdentity.helperMachServiceName)'"))
+        #expect(script.contains("/usr/bin/pkill -f '[R]ockxyHelperTool'"))
+        #expect(!script.contains("/usr/bin/pkill -f 'RockxyHelperTool'"))
+        #expect(script.contains("/bin/rm -f '/Library/PrivilegedHelperTools/\(TestIdentity.helperMachServiceName)'"))
+        #expect(script.contains("/bin/rm -f '/Library/LaunchDaemons/\(TestIdentity.helperPlistName)'"))
+        #expect(script.contains("/bin/launchctl print system/'\(TestIdentity.helperMachServiceName)'"))
+        #expect(script.contains("direct-proxy-watchdog"))
+        #expect(script.contains("proxy-backup-direct.plist"))
+        #expect(!script.contains("sfltool resetbtm"))
+    }
+
+    @Test("hard force remove command reports signal termination clearly")
+    func hardForceRemoveSignalFailureMessage() {
+        let error = HelperManager.ForceRemoveError.commandTerminated(signal: 15, output: "")
+
+        #expect(error.localizedDescription.contains("signal 15"))
+    }
+
+    @Test("hard force remove script only resets Background Items when explicitly requested")
+    func hardForceRemoveScriptIncludesBTMResetOnlyWhenRequested() {
+        let script = HelperManager.forceRemoveShellScript(
+            identity: makeForceRemoveIdentity(),
+            resetBackgroundItems: true
+        )
+
+        #expect(script.contains("/usr/bin/sfltool resetbtm"))
+    }
+
+    @Test("privileged AppleScript wraps force remove command with administrator approval")
+    func privilegedAppleScriptUsesAdministratorPrivileges() {
+        let script = HelperManager.privilegedAppleScript(for: "echo \"Rockxy\"")
+
+        #expect(script.contains("do shell script"))
+        #expect(script.contains("with administrator privileges"))
+        #expect(script.contains("\\\"Rockxy\\\""))
+    }
+
+    // MARK: - Xcode Legacy Helper Install Fallback
+
+    @Test("legacy install fallback is limited to Xcode DerivedData app bundles")
+    func legacyInstallFallbackDetectionIsXcodeOnly() {
+        let xcodeBundle = URL(
+            fileURLWithPath: "/Users/test/Library/Developer/Xcode/DerivedData/Rockxy-abc/Build/Products/Debug/Rockxy.app"
+        )
+        let releaseBundle = URL(fileURLWithPath: "/Applications/Rockxy.app")
+
+        #expect(HelperManager.shouldUseLegacyInstallFallbackForCurrentBundle(bundleURL: xcodeBundle))
+        #expect(!HelperManager.shouldUseLegacyInstallFallbackForCurrentBundle(bundleURL: releaseBundle))
+    }
+
+    @Test("legacy install script bootstraps the shared helper identity for Xcode runs")
+    func legacyInstallScriptBootstrapsSharedHelperIdentity() {
+        let identity = makeForceRemoveIdentity()
+        let helperPath = "/tmp/Rockxy.app/Contents/Library/HelperTools/RockxyHelperTool"
+        let script = HelperManager.legacyInstallShellScript(
+            identity: identity,
+            bundledHelperPath: helperPath
+        )
+
+        let installedHelperPath = "/Library/PrivilegedHelperTools/\(TestIdentity.helperMachServiceName)"
+        let plistPath = "/Library/LaunchDaemons/\(TestIdentity.helperPlistName)"
+
+        #expect(script.contains("/usr/bin/install -o root -g wheel -m 755 '\(helperPath)' '\(installedHelperPath)'"))
+        #expect(script.contains("/bin/launchctl bootstrap system '\(plistPath)'"))
+        #expect(script.contains("/bin/launchctl kickstart -k system/'\(TestIdentity.helperMachServiceName)'"))
+        #expect(script.contains("direct-proxy-watchdog"))
+        #expect(script.contains("proxy-backup-direct.plist"))
+    }
+
     // MARK: - Uninstall Registration Status Reset
 
     @Test("injecting notInstalled state resets registrationStatus via injectHelperStateForTests")
@@ -515,6 +593,18 @@ private func signedBundleWithEmbeddedMetadata() -> Bundle? {
 }
 
 private let expectedHelperBundleProgram = "Contents/Library/HelperTools/RockxyHelperTool"
+
+private func makeForceRemoveIdentity() -> RockxyIdentity {
+    RockxyIdentity(infoDictionary: [
+        "CFBundleDisplayName": "Rockxy",
+        "CFBundleIdentifier": TestIdentity.communityBundleIdentifier,
+        "RockxyFamilyNamespace": TestIdentity.familyNamespace,
+        "RockxyHelperBundleIdentifier": TestIdentity.helperBundleIdentifier,
+        "RockxyHelperMachServiceName": TestIdentity.helperMachServiceName,
+        "RockxyHelperPlistName": TestIdentity.helperPlistName,
+        "RockxyAllowedCallerIdentifiers": TestIdentity.expectedAllowedCallerIdentifiers.joined(separator: " "),
+    ])
+}
 
 private enum HelperBinaryKind {
     case regularFile(permissions: Int)

--- a/RockxyTests/Models/Rules/ModifyHeaderRuleBuilderTests.swift
+++ b/RockxyTests/Models/Rules/ModifyHeaderRuleBuilderTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+struct ModifyHeaderRuleBuilderTests {
+    @Test("Wildcard matching rule is converted with Block List semantics")
+    func wildcardPatternConversion() {
+        let rule = ModifyHeaderRuleBuilder.build(
+            ruleName: "",
+            rawPattern: " https://example.com/api/* ",
+            httpMethod: .post,
+            matchType: .wildcard,
+            includeSubpaths: true,
+            operations: [
+                HeaderOperation(type: .add, headerName: "X-Debug", headerValue: "1"),
+            ]
+        )
+
+        #expect(rule.name == "https://example.com/api/*")
+        #expect(rule.matchCondition.method == "POST")
+        #expect(rule.matchCondition.urlPattern == #"https:\/\/example\.com\/api\/.*"#)
+    }
+
+    @Test("Exact wildcard matching appends URL boundary")
+    func exactWildcardPatternConversion() {
+        let rule = ModifyHeaderRuleBuilder.build(
+            ruleName: "Exact",
+            rawPattern: "https://example.com/api",
+            httpMethod: .any,
+            matchType: .wildcard,
+            includeSubpaths: false,
+            operations: [
+                HeaderOperation(type: .remove, headerName: "Server", headerValue: nil),
+            ]
+        )
+
+        #expect(rule.name == "Exact")
+        #expect(rule.matchCondition.method == nil)
+        #expect(rule.matchCondition.urlPattern == #"https:\/\/example\.com\/api($|[?#])"#)
+    }
+
+    @Test("Regex matching preserves source and edited rule identity")
+    func regexPatternPreservesIdentity() {
+        let existing = ProxyRule(
+            name: "Old",
+            isEnabled: false,
+            matchCondition: RuleMatchCondition(urlPattern: "old"),
+            action: .modifyHeader(operations: []),
+            priority: 7
+        )
+
+        let rule = ModifyHeaderRuleBuilder.build(
+            existingRule: existing,
+            ruleName: " Updated ",
+            rawPattern: ".*api\\.example\\.com.*",
+            httpMethod: .get,
+            matchType: .regex,
+            includeSubpaths: true,
+            operations: [
+                HeaderOperation(type: .replace, headerName: "Cache-Control", headerValue: "no-cache"),
+            ]
+        )
+
+        #expect(rule.id == existing.id)
+        #expect(rule.name == "Updated")
+        #expect(rule.isEnabled == false)
+        #expect(rule.priority == 7)
+        #expect(rule.matchCondition.method == "GET")
+        #expect(rule.matchCondition.urlPattern == ".*api\\.example\\.com.*")
+    }
+}

--- a/RockxyTests/Models/UI/DomainGroupingTests.swift
+++ b/RockxyTests/Models/UI/DomainGroupingTests.swift
@@ -1,0 +1,76 @@
+import Foundation
+@testable import Rockxy
+import Testing
+
+// Regression tests for sidebar domain grouping.
+
+// MARK: - DomainGroupingTests
+
+@MainActor
+struct DomainGroupingTests {
+    @Test("Groups root domains, subdomains, and paths into a recursive tree")
+    func recursiveDomainTree() throws {
+        let coordinator = MainContentCoordinator()
+        let version = transaction("https://proxyman.com/osx/version.xml", sequence: 0)
+        let events = transaction("https://proxyman.com/v1/events", sequence: 1)
+        let apiEvents = transaction("https://api.proxyman.com/v1/events", sequence: 2, statusCode: 500)
+        coordinator.transactions = [version, events, apiEvents]
+
+        coordinator.rebuildSidebarIndexes()
+
+        let root = try #require(coordinator.domainTree.first { $0.domain == "proxyman.com" })
+        #expect(root.requestCount == 3)
+        #expect(root.errorCount == 1)
+        #expect(root.children.contains { $0.domain == "/osx" })
+        #expect(root.children.contains { $0.domain == "/v1" })
+
+        let api = try #require(root.children.first { $0.domain == "api.proxyman.com" })
+        #expect(api.kind == .host)
+        #expect(api.requestCount == 1)
+        #expect(api.errorCount == 1)
+        #expect(api.children.first?.domain == "/v1")
+    }
+
+    @Test("Uses common multi-part public suffixes for registrable domain grouping")
+    func multiPartPublicSuffix() throws {
+        let coordinator = MainContentCoordinator()
+        coordinator.transactions = [
+            transaction("https://api.example.co.uk/orders", sequence: 0),
+            transaction("https://cdn.example.co.uk/assets/app.js", sequence: 1),
+        ]
+
+        coordinator.rebuildSidebarIndexes()
+
+        let root = try #require(coordinator.domainTree.first)
+        #expect(root.domain == "example.co.uk")
+        #expect(root.children.map(\.domain).contains("api.example.co.uk"))
+        #expect(root.children.map(\.domain).contains("cdn.example.co.uk"))
+    }
+
+    @Test("Collapses dynamic path segments under an id group")
+    func dynamicPathSegments() throws {
+        let coordinator = MainContentCoordinator()
+        coordinator.transactions = [
+            transaction("https://api.example.com/users/100", sequence: 0),
+            transaction("https://api.example.com/users/200", sequence: 1),
+        ]
+
+        coordinator.rebuildSidebarIndexes()
+
+        let root = try #require(coordinator.domainTree.first { $0.domain == "example.com" })
+        let host = try #require(root.children.first { $0.domain == "api.example.com" })
+        let users = try #require(host.children.first { $0.domain == "/users" })
+        let idGroup = try #require(users.children.first)
+        #expect(idGroup.domain == "/{id}")
+        #expect(idGroup.pathPrefix == "/users/")
+        #expect(idGroup.requestCount == 2)
+    }
+
+    // MARK: Private
+
+    private func transaction(_ url: String, sequence: Int, statusCode: Int = 200) -> HTTPTransaction {
+        let transaction = TestFixtures.makeTransaction(url: url, statusCode: statusCode)
+        transaction.sequenceNumber = sequence
+        return transaction
+    }
+}

--- a/RockxyTests/Views/Main/FilteringTests.swift
+++ b/RockxyTests/Views/Main/FilteringTests.swift
@@ -176,6 +176,31 @@ struct FilteringTests {
         #expect(coordinator.filteredTransactions[0].id == match.id)
     }
 
+    @Test("Sidebar domain filter does not match partial host suffixes")
+    func sidebarDomainFilterRequiresBoundary() {
+        let coordinator = MainContentCoordinator()
+        let match = TestFixtures.makeTransaction(url: "https://api.example.com/test")
+        let noMatch = TestFixtures.makeTransaction(url: "https://badexample.com/test")
+        coordinator.transactions = [match, noMatch]
+        coordinator.filterCriteria.sidebarDomain = "example.com"
+        coordinator.recomputeFilteredTransactions()
+        #expect(coordinator.filteredTransactions.count == 1)
+        #expect(coordinator.filteredTransactions[0].id == match.id)
+    }
+
+    @Test("Sidebar path filter narrows selected domain group")
+    func sidebarPathFilter() {
+        let coordinator = MainContentCoordinator()
+        let users = TestFixtures.makeTransaction(url: "https://api.example.com/v1/users")
+        let events = TestFixtures.makeTransaction(url: "https://api.example.com/v1/events")
+        let otherPath = TestFixtures.makeTransaction(url: "https://api.example.com/v2/users")
+        coordinator.transactions = [users, events, otherPath]
+        coordinator.filterCriteria.sidebarDomain = "api.example.com"
+        coordinator.filterCriteria.sidebarPathPrefix = "/v1"
+        coordinator.recomputeFilteredTransactions()
+        #expect(coordinator.filteredTransactions.map(\.id) == [users.id, events.id])
+    }
+
     @Test("Sidebar app filters by exact match")
     func sidebarAppFilter() {
         let coordinator = MainContentCoordinator()


### PR DESCRIPTION
## Summary
- Add structured domain grouping for the sidebar with expandable hierarchy and persisted navigation state.
- Improve Helper lifecycle handling with recoverable force reset flows, Xcode-run fallback handling, and clearer helper mismatch/reinstall states.
- Polish related settings/sidebar UI and improve modify headers editor behavior included on develop.

## Validation
- `xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -destination 'platform=macOS' -only-testing:RockxyTests/HelperManagerTests test`\n- `xcodebuild -project Rockxy.xcodeproj -scheme Rockxy -configuration Release -destination 'generic/platform=macOS' -archivePath /tmp/RockxyReleaseSafety.xcarchive archive`\n- `git diff --check`\n\n## Notes\n- Helper identity remains shared through the existing Rockxy configuration; the Xcode-only fallback is guarded to DerivedData build products and does not apply to release archive/export paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added force reset option for the Rockxy Helper with administrator privileges and optional background items reset.
  * Added path-prefix filtering for domains in the sidebar for granular traffic filtering.
  * Added HTTP header modification rules with pattern matching and method filtering support.

* **Improvements**
  * Enhanced domain sidebar organization with improved path grouping and dynamic segment collapsing.
  * Improved helper recovery when XPC connections fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->